### PR TITLE
Add portable DPI scaling support

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndSource.cs
@@ -459,6 +459,31 @@ namespace System.Windows.Interop
             OnDpiChangedAfterParent(e);
         }
 
+        internal bool SetPortableDeviceScale(double dpiScaleX, double dpiScaleY)
+        {
+            if (_portableOwner == null || _hwndTarget == null)
+            {
+                throw new InvalidOperationException("Portable device scale can only be set on a portable HwndSource.");
+            }
+
+            DpiScale oldDpi = _hwndTarget.CurrentDpiScale;
+            DpiScale newDpi = new DpiScale(dpiScaleX, dpiScaleY);
+            if (oldDpi.Equals(newDpi))
+            {
+                return true;
+            }
+
+            var args = new HwndDpiChangedEventArgs(oldDpi, newDpi, Rect.Empty);
+            DpiChanged?.Invoke(this, args);
+            if (args.Handled)
+            {
+                return false;
+            }
+
+            _hwndTarget.SetPortableDeviceScale(dpiScaleX, dpiScaleY);
+            return true;
+        }
+
         /// <summary>
         ///     Announces when the DPI is going to change for the window. If the user handles this event,
         ///     WPF does not scale any visual.

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/InterOp/HwndTarget.cs
@@ -333,6 +333,37 @@ namespace System.Windows.Interop
                     0, 0));
         }
 
+        internal void SetPortableDeviceScale(double dpiScaleX, double dpiScaleY)
+        {
+            if (!_isPortable)
+            {
+                throw new InvalidOperationException("Portable device scale can only be set on a portable HwndTarget.");
+            }
+
+            DpiScale2 oldDpi = CurrentDpiScale;
+            DpiScale2 newDpi = DpiScale2.FromPixelsPerInch(
+                ToPositiveFiniteScale(dpiScaleX) * DpiUtil.DefaultPixelsPerInch,
+                ToPositiveFiniteScale(dpiScaleY) * DpiUtil.DefaultPixelsPerInch);
+            if (oldDpi.Equals(newDpi))
+            {
+                return;
+            }
+
+            CurrentDpiScale = newDpi;
+            _worldTransform = new MatrixTransform(
+                new Matrix(
+                    newDpi.DpiScaleX, 0,
+                    0, newDpi.DpiScaleY,
+                    0, 0));
+            PropagateDpiChangeToRootVisual(oldDpi, newDpi);
+            StateChangedCallback(new object[]
+            {
+                HostStateFlags.WorldTransform,
+                _worldTransform.Matrix,
+                Rect.Empty
+            });
+        }
+
         private static double ToPositiveFiniteScale(double value)
         {
             return double.IsFinite(value) && value > 0.0 ? value : 1.0;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortablePresentationSource.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortablePresentationSource.cs
@@ -273,7 +273,20 @@ namespace System.Windows
         internal void SetDeviceScale(double dpiScaleX, double dpiScaleY)
         {
             VerifyNotDisposed();
+            Matrix currentTransform = _compositionTarget.TransformToDevice;
+            if (currentTransform.M11 == dpiScaleX && currentTransform.M22 == dpiScaleY)
+            {
+                return;
+            }
+
+            if (!_portableHwndSource.SetPortableDeviceScale(dpiScaleX, dpiScaleY))
+            {
+                return;
+            }
+
             _compositionTarget.SetDeviceScale(dpiScaleX, dpiScaleY);
+            ApplyRootVisualDpi(dpiScaleX, dpiScaleY);
+            ApplyRootVisualLayout();
             RequestRender();
         }
 
@@ -389,6 +402,8 @@ namespace System.Windows
                 }
 
                 _compositionTarget.RootVisual = rootVisual;
+                Matrix transformToDevice = _compositionTarget.TransformToDevice;
+                ApplyRootVisualDpi(transformToDevice.M11, transformToDevice.M22);
                 UIElement.PropagateResumeLayout(null, rootVisual);
                 ApplyRootVisualLayout();
             }
@@ -426,6 +441,41 @@ namespace System.Windows
             rootUIElement.Measure(_clientSize);
             rootUIElement.Arrange(new Rect(new Point(), _clientSize));
             rootUIElement.UpdateLayout();
+        }
+
+        private void ApplyRootVisualDpi(double dpiScaleX, double dpiScaleY)
+        {
+            if (_rootVisual == null)
+            {
+                return;
+            }
+
+            DpiScale newDpi = new DpiScale(dpiScaleX, dpiScaleY);
+            if (VisualTreeHelper.GetDpi(_rootVisual).Equals(newDpi))
+            {
+                return;
+            }
+
+            VisualTreeHelper.SetRootDpi(_rootVisual, newDpi);
+            InvalidateDpiMeasure(_rootVisual);
+        }
+
+        private static void InvalidateDpiMeasure(DependencyObject dependencyObject)
+        {
+            int childCount = VisualTreeHelper.GetChildrenCount(dependencyObject);
+            for (int i = 0; i < childCount; i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(dependencyObject, i);
+                if (child != null)
+                {
+                    InvalidateDpiMeasure(child);
+                }
+            }
+
+            if (dependencyObject is UIElement element)
+            {
+                element.InvalidateMeasure();
+            }
         }
 
         private bool TryUpdateRootVisualClientSize(out double width, out double height)

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/PortablePresentationSourceTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/System/Windows/PortablePresentationSourceTests.cs
@@ -9,6 +9,51 @@ namespace System.Windows;
 [Collection("Sequential")]
 public class PortablePresentationSourceTests
 {
+    [Fact]
+    public void InitialDeviceScaleIsAppliedToRootVisual()
+    {
+        using IPortablePresentationSourceHost source = PortablePresentationSourceHost.Create(2.0, 1.5);
+        var root = new DpiTrackingElement();
+
+        source.RootVisual = root;
+        source.SetClientSize(400.0, 300.0);
+
+        DpiScale dpi = VisualTreeHelper.GetDpi(root);
+        dpi.DpiScaleX.Should().BeApproximately(2.0, 0.000001);
+        dpi.DpiScaleY.Should().BeApproximately(1.5, 0.000001);
+        root.DpiChangedCount.Should().Be(1);
+        root.MeasureCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void DeviceScaleChangeUpdatesVisualDpiLayoutAndHwndSource()
+    {
+        using IPortablePresentationSourceHost source = PortablePresentationSourceHost.Create();
+        var portableSource = (PortablePresentationSource)(PresentationSource)source;
+        var root = new DpiTrackingElement();
+        int hwndDpiChangedCount = 0;
+        portableSource.HwndSource.DpiChanged += (_, e) =>
+        {
+            hwndDpiChangedCount++;
+            e.OldDpi.DpiScaleX.Should().BeApproximately(1.0, 0.000001);
+            e.NewDpi.DpiScaleX.Should().BeApproximately(2.0, 0.000001);
+        };
+        source.RootVisual = root;
+        source.SetClientSize(400.0, 300.0);
+        int measureCountBeforeDpiChange = root.MeasureCount;
+
+        source.SetDeviceScale(2.0, 1.5);
+
+        CompositionTarget compositionTarget = ((PresentationSource)source).CompositionTarget;
+        compositionTarget.TransformToDevice.M11.Should().BeApproximately(2.0, 0.000001);
+        compositionTarget.TransformToDevice.M22.Should().BeApproximately(1.5, 0.000001);
+        VisualTreeHelper.GetDpi(root).DpiScaleX.Should().BeApproximately(2.0, 0.000001);
+        VisualTreeHelper.GetDpi(root).DpiScaleY.Should().BeApproximately(1.5, 0.000001);
+        root.DpiChangedCount.Should().Be(1);
+        root.MeasureCount.Should().BeGreaterThan(measureCountBeforeDpiChange);
+        hwndDpiChangedCount.Should().Be(1);
+    }
+
     [Theory]
     [InlineData(1.0, 1.0)]
     [InlineData(2.0, 2.0)]
@@ -251,6 +296,25 @@ public class PortablePresentationSourceTests
         protected override HitTestResult HitTestCore(PointHitTestParameters hitTestParameters)
         {
             return new PointHitTestResult(this, hitTestParameters.HitPoint);
+        }
+    }
+
+    private sealed class DpiTrackingElement : UIElement
+    {
+        internal int DpiChangedCount { get; private set; }
+
+        internal int MeasureCount { get; private set; }
+
+        protected override void OnDpiChanged(DpiScale oldDpi, DpiScale newDpi)
+        {
+            DpiChangedCount++;
+            base.OnDpiChanged(oldDpi, newDpi);
+        }
+
+        protected override Size MeasureCore(Size availableSize)
+        {
+            MeasureCount++;
+            return new Size(100.0, 50.0);
         }
     }
 }

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -1203,7 +1203,8 @@ public sealed class WpfManagedProjectGraphTests
         Assert.DoesNotContain("System.Reflection.TargetInvocationException", proGpuHost, StringComparison.Ordinal);
         Assert.DoesNotContain("GetProperty(", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("exception.GetBaseException()", proGpuHost, StringComparison.Ordinal);
-        Assert.Contains("UpdateClientSizeFromNativeResize(size, framebufferSize, monitorDpiScale);", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("WpfDeviceScale contentScale = ResolveCurrentWindowContentScale();", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("UsesMonitorScaledWindowCoordinates());", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("var clientSize = _window.Size;", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("var framebufferSize = _window.FramebufferSize;", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("UpdatePortablePresentationSourceClientSize((uint)_clientWidth, (uint)_clientHeight);", proGpuHost, StringComparison.Ordinal);
@@ -1220,9 +1221,10 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("var logicalSize = ResolveLogicalClientSize(", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("var logicalWidth = (uint)Math.Max(1, clientWidth);", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("var logicalHeight = (uint)Math.Max(1, clientHeight);", proGpuHost, StringComparison.Ordinal);
-        Assert.Contains("var fallbackScale = NormalizeMonitorDpiScale(monitorDpiScale);", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("var fallbackScaleX = NormalizeMonitorDpiScale(contentScale.X);", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("var fallbackScaleY = NormalizeMonitorDpiScale(contentScale.Y);", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("framebufferSize.X > 0", proGpuHost, StringComparison.Ordinal);
-        Assert.Contains("Math.Ceiling(logicalWidth * fallbackScale)", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("Math.Ceiling(logicalWidth * fallbackScaleX)", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("PlatformServices.Monitors.GetMonitors()", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("using ProGPU.Backend;", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("ResolveMonitorDpiScaleWithPlatformFallback(", proGpuHost, StringComparison.Ordinal);
@@ -1247,7 +1249,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.DoesNotContain("sel_registerName(\"screen\")", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("NativeResizeAppliesMaximizedWslgClientSizeInsteadOfStaleCache", proGpuWindowHostTests, StringComparison.Ordinal);
         Assert.Contains("NativeResizeDoesNotUseStaleRootRenderSizeForRealLogicalResize", proGpuWindowHostTests, StringComparison.Ordinal);
-        Assert.Contains("Silk.NET's IWindow.Size contract is the logical client size", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("GLFW_SCALE_TO_MONITOR is different on X11", proGpuHost, StringComparison.Ordinal);
         Assert.DoesNotContain("backingScaleFactor", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("var dpiScaleX = pixelWidth / (double)logicalWidth", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("var dpiScaleY = pixelHeight / (double)logicalHeight", proGpuHost, StringComparison.Ordinal);
@@ -1268,6 +1270,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("NormalizeInputEventForCurrentRenderSurface(", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("NormalizeInputEventForRenderSurfaceGeometry(", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("NativeInputCoordinatesLookPhysical(", proGpuHost, StringComparison.Ordinal);
+        Assert.Contains("NativeInputCoordinatesArePhysical(", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("internal event EventHandler? UpdateTick;", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("UpdateTick?.Invoke(this, EventArgs.Empty);", proGpuHost, StringComparison.Ordinal);
         Assert.Contains("internal bool TryRequestNativeLoopWakeup()", proGpuHost, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Platform/SilkNetGlfwDpiServiceTests.cs
+++ b/src/ProGPU.Wpf.Tests/Platform/SilkNetGlfwDpiServiceTests.cs
@@ -1,0 +1,52 @@
+using System.Windows.Media.ProGPU.Platform;
+using Xunit;
+
+namespace ProGPU.Wpf.Tests.Platform;
+
+public sealed class SilkNetGlfwDpiServiceTests
+{
+    [Theory]
+    [InlineData(1.0, 1.0)]
+    [InlineData(2.0, 1.5)]
+    [InlineData(1.3333333, 1.6666667)]
+    public void TryNormalizeContentScaleAcceptsFinitePositiveScales(double scaleX, double scaleY)
+    {
+        bool normalized = SilkNetGlfwDpiService.TryNormalizeContentScale(scaleX, scaleY, out WpfDeviceScale scale);
+
+        Assert.True(normalized);
+        Assert.Equal(Math.Round(scaleX, 4), scale.X);
+        Assert.Equal(Math.Round(scaleY, 4), scale.Y);
+    }
+
+    [Theory]
+    [InlineData(0.0, 1.0)]
+    [InlineData(1.0, 0.0)]
+    [InlineData(-1.0, 1.0)]
+    [InlineData(double.NaN, 1.0)]
+    [InlineData(double.PositiveInfinity, 1.0)]
+    [InlineData(9.0, 1.0)]
+    public void TryNormalizeContentScaleRejectsInvalidScales(double scaleX, double scaleY)
+    {
+        Assert.False(SilkNetGlfwDpiService.TryNormalizeContentScale(scaleX, scaleY, out _));
+    }
+
+    [Theory]
+    [InlineData(true, true, false, true)]
+    [InlineData(true, false, true, true)]
+    [InlineData(true, false, false, false)]
+    [InlineData(false, true, false, false)]
+    [InlineData(false, false, true, false)]
+    public void UsesMonitorScaledWindowCoordinatesMatchesGlfwBackendBehavior(
+        bool hintsConfigured,
+        bool hasX11Window,
+        bool hasWin32Window,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            SilkNetGlfwDpiService.UsesMonitorScaledWindowCoordinates(
+                hintsConfigured,
+                hasX11Window,
+                hasWin32Window));
+    }
+}

--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -1273,6 +1273,52 @@ public sealed class ProGpuWpfWindowHostTests
     }
 
     [Fact]
+    public void NativeInputCoordinatesArePhysicalConvertsScaledX11PlatformInputInsideLogicalBounds()
+    {
+        var geometry = ProGpuWpfWindowHost.ResolveRenderSurfaceGeometry(
+            clientWidth: 760,
+            clientHeight: 560,
+            framebufferSize: new Vector2D<int>(1520, 1120),
+            monitorDpiScale: 2.0);
+        var input = new WpfInputEventArgs(
+            WpfInputEventKind.MouseDown,
+            x: 320,
+            y: 180,
+            button: WpfMouseButton.Left);
+
+        Assert.True(
+            ProGpuWpfWindowHost.NativeInputCoordinatesArePhysical(
+                isNativePlatformEvent: true,
+                usesMonitorScaledWindowCoordinates: true,
+                new Vector2D<int>(1520, 1120),
+                geometry,
+                input));
+    }
+
+    [Fact]
+    public void NativeInputCoordinatesArePhysicalKeepsDiagnosticInputLogical()
+    {
+        var geometry = ProGpuWpfWindowHost.ResolveRenderSurfaceGeometry(
+            clientWidth: 760,
+            clientHeight: 560,
+            framebufferSize: new Vector2D<int>(1520, 1120),
+            monitorDpiScale: 2.0);
+        var input = new WpfInputEventArgs(
+            WpfInputEventKind.MouseDown,
+            x: 320,
+            y: 180,
+            button: WpfMouseButton.Left);
+
+        Assert.False(
+            ProGpuWpfWindowHost.NativeInputCoordinatesArePhysical(
+                isNativePlatformEvent: false,
+                usesMonitorScaledWindowCoordinates: true,
+                new Vector2D<int>(1520, 1120),
+                geometry,
+                input));
+    }
+
+    [Fact]
     public void NormalizeInputEventForRenderSurfaceGeometryLeavesKeyboardInputUnchanged()
     {
         var geometry = ProGpuWpfWindowHost.ResolveRenderSurfaceGeometry(
@@ -1360,6 +1406,34 @@ public sealed class ProGpuWpfWindowHostTests
             monitorDpiScale: 2.0);
 
         Assert.Equal(new Vector2D<int>(420, 840), logicalSize);
+    }
+
+    [Fact]
+    public void ResolveLogicalClientSizeConvertsScaledX11CoordinatesToDips()
+    {
+        var logicalSize = ProGpuWpfWindowHost.ResolveLogicalClientSize(
+            nativeSize: new Vector2D<int>(1960, 1280),
+            framebufferSize: new Vector2D<int>(1960, 1280),
+            cachedWidth: 980,
+            cachedHeight: 640,
+            contentScale: new WpfDeviceScale(2.0, 2.0),
+            windowSizeIsScaledByContentScale: true);
+
+        Assert.Equal(new Vector2D<int>(980, 640), logicalSize);
+    }
+
+    [Fact]
+    public void ResolveLogicalClientSizeKeepsWaylandAndMacOsCoordinatesInDips()
+    {
+        var logicalSize = ProGpuWpfWindowHost.ResolveLogicalClientSize(
+            nativeSize: new Vector2D<int>(980, 640),
+            framebufferSize: new Vector2D<int>(1960, 1280),
+            cachedWidth: 980,
+            cachedHeight: 640,
+            contentScale: new WpfDeviceScale(2.0, 2.0),
+            windowSizeIsScaledByContentScale: false);
+
+        Assert.Equal(new Vector2D<int>(980, 640), logicalSize);
     }
 
     [Fact]

--- a/src/ProGPU.Wpf/Platform/SilkNetGlfwDpiService.cs
+++ b/src/ProGPU.Wpf/Platform/SilkNetGlfwDpiService.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Runtime.InteropServices;
+using Silk.NET.Core.Contexts;
+using Silk.NET.GLFW;
+using Silk.NET.Windowing;
+
+namespace System.Windows.Media.ProGPU.Platform;
+
+internal readonly record struct WpfDeviceScale(double X, double Y)
+{
+    internal double Average => (X + Y) / 2.0;
+}
+
+internal static class SilkNetGlfwDpiService
+{
+    // These GLFW 3.4 hints are newer than the enums in Silk.NET 2.23.
+    private const int GlfwScaleToMonitor = 0x0002200C;
+    private const int GlfwScaleFramebuffer = 0x0002200D;
+
+    private static readonly object s_exportsGate = new();
+    private static GlfwDpiExports? s_exports;
+    private static bool s_exportsResolved;
+
+    internal static bool TryConfigureDpiWindowHints()
+    {
+        try
+        {
+            Glfw glfw = GlfwProvider.GLFW.Value;
+            glfw.WindowHint((WindowHintBool)GlfwScaleToMonitor, true);
+            glfw.WindowHint((WindowHintBool)GlfwScaleFramebuffer, true);
+            return true;
+        }
+        catch (DllNotFoundException)
+        {
+            return false;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return false;
+        }
+        catch (BadImageFormatException)
+        {
+            return false;
+        }
+        catch (GlfwException)
+        {
+            return false;
+        }
+    }
+
+    internal static bool TryGetWindowContentScale(IWindow? window, out WpfDeviceScale scale)
+    {
+        scale = default;
+        if (!TryGetGlfwWindowHandle(window, out nint glfwWindow) ||
+            !TryGetExports(out GlfwDpiExports? exports))
+        {
+            return false;
+        }
+
+        try
+        {
+            exports!.GetWindowContentScale(glfwWindow, out float scaleX, out float scaleY);
+            return TryNormalizeContentScale(scaleX, scaleY, out scale);
+        }
+        catch (AccessViolationException)
+        {
+            scale = default;
+            return false;
+        }
+    }
+
+    internal static IDisposable? TrySubscribeToWindowContentScale(
+        IWindow? window,
+        Action<WpfDeviceScale> contentScaleChanged)
+    {
+        ArgumentNullException.ThrowIfNull(contentScaleChanged);
+
+        if (!TryGetGlfwWindowHandle(window, out nint glfwWindow) ||
+            !TryGetExports(out GlfwDpiExports? exports))
+        {
+            return null;
+        }
+
+        GlfwWindowContentScaleCallback callback = (_, scaleX, scaleY) =>
+        {
+            if (TryNormalizeContentScale(scaleX, scaleY, out WpfDeviceScale scale))
+            {
+                contentScaleChanged(scale);
+            }
+        };
+
+        nint callbackPointer = Marshal.GetFunctionPointerForDelegate(callback);
+        nint previousCallback = exports!.SetWindowContentScaleCallback(glfwWindow, callbackPointer);
+        return new ContentScaleSubscription(
+            glfwWindow,
+            exports.SetWindowContentScaleCallback,
+            previousCallback,
+            callback);
+    }
+
+    internal static bool UsesMonitorScaledWindowCoordinates(
+        bool dpiWindowHintsConfigured,
+        bool hasX11Window,
+        bool hasWin32Window)
+    {
+        return dpiWindowHintsConfigured && (hasX11Window || hasWin32Window);
+    }
+
+    internal static bool TryNormalizeContentScale(
+        double scaleX,
+        double scaleY,
+        out WpfDeviceScale scale)
+    {
+        scale = default;
+        if (!IsUsableScale(scaleX) || !IsUsableScale(scaleY))
+        {
+            return false;
+        }
+
+        scale = new WpfDeviceScale(
+            NormalizeScale(scaleX),
+            NormalizeScale(scaleY));
+        return true;
+    }
+
+    private static bool TryGetGlfwWindowHandle(IWindow? window, out nint glfwWindow)
+    {
+        glfwWindow = 0;
+        if (window is not INativeWindowSource nativeWindowSource)
+        {
+            return false;
+        }
+
+        IntPtr? handle = nativeWindowSource.Native?.Glfw;
+        if (!handle.HasValue || handle.Value == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        glfwWindow = handle.Value;
+        return true;
+    }
+
+    private static bool TryGetExports(out GlfwDpiExports? exports)
+    {
+        lock (s_exportsGate)
+        {
+            if (!s_exportsResolved)
+            {
+                s_exports = TryLoadExports();
+                s_exportsResolved = true;
+            }
+
+            exports = s_exports;
+            return exports != null;
+        }
+    }
+
+    private static GlfwDpiExports? TryLoadExports()
+    {
+        string[] libraryNames = OperatingSystem.IsWindows()
+            ? new[] { "glfw3.dll", "glfw3" }
+            : OperatingSystem.IsMacOS()
+                ? new[] { "libglfw.3.dylib", "libglfw.dylib", "glfw3" }
+                : new[] { "libglfw.so.3", "libglfw.so", "glfw3" };
+
+        foreach (string libraryName in libraryNames)
+        {
+            if (!NativeLibrary.TryLoad(libraryName, out nint libraryHandle))
+            {
+                continue;
+            }
+
+            if (NativeLibrary.TryGetExport(libraryHandle, "glfwGetWindowContentScale", out nint getScale) &&
+                NativeLibrary.TryGetExport(libraryHandle, "glfwSetWindowContentScaleCallback", out nint setCallback))
+            {
+                return new GlfwDpiExports(
+                    libraryHandle,
+                    Marshal.GetDelegateForFunctionPointer<GlfwGetWindowContentScale>(getScale),
+                    Marshal.GetDelegateForFunctionPointer<GlfwSetWindowContentScaleCallback>(setCallback));
+            }
+
+            NativeLibrary.Free(libraryHandle);
+        }
+
+        return null;
+    }
+
+    private static bool IsUsableScale(double scale)
+    {
+        return double.IsFinite(scale) && scale > 0.0 && scale <= 8.0;
+    }
+
+    private static double NormalizeScale(double scale)
+    {
+        return Math.Round(scale, 4, MidpointRounding.AwayFromZero);
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void GlfwGetWindowContentScale(
+        nint window,
+        out float scaleX,
+        out float scaleY);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate nint GlfwSetWindowContentScaleCallback(
+        nint window,
+        nint callback);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void GlfwWindowContentScaleCallback(
+        nint window,
+        float scaleX,
+        float scaleY);
+
+    private sealed record GlfwDpiExports(
+        nint LibraryHandle,
+        GlfwGetWindowContentScale GetWindowContentScale,
+        GlfwSetWindowContentScaleCallback SetWindowContentScaleCallback);
+
+    private sealed class ContentScaleSubscription : IDisposable
+    {
+        private readonly nint _window;
+        private readonly GlfwSetWindowContentScaleCallback _setCallback;
+        private readonly nint _previousCallback;
+        private GlfwWindowContentScaleCallback? _callback;
+
+        internal ContentScaleSubscription(
+            nint window,
+            GlfwSetWindowContentScaleCallback setCallback,
+            nint previousCallback,
+            GlfwWindowContentScaleCallback callback)
+        {
+            _window = window;
+            _setCallback = setCallback;
+            _previousCallback = previousCallback;
+            _callback = callback;
+        }
+
+        public void Dispose()
+        {
+            if (_callback == null)
+            {
+                return;
+            }
+
+            _setCallback(_window, _previousCallback);
+            _callback = null;
+        }
+    }
+}

--- a/src/ProGPU.Wpf/Platform/SilkNetWpfMonitorService.cs
+++ b/src/ProGPU.Wpf/Platform/SilkNetWpfMonitorService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Silk.NET.GLFW;
 using Silk.NET.Maths;
 using Silk.NET.Windowing;
 
@@ -12,7 +13,7 @@ public sealed class SilkNetWpfMonitorService : IWpfMonitorService
     private readonly Func<IMonitor, double?>? _getDpiScale;
 
     public SilkNetWpfMonitorService()
-        : this(GetDefaultMonitors, GetDefaultMainMonitor)
+        : this(GetDefaultMonitors, GetDefaultMainMonitor, TryGetGlfwMonitorContentScale)
     {
     }
 
@@ -22,6 +23,7 @@ public sealed class SilkNetWpfMonitorService : IWpfMonitorService
 
         _getMonitors = platform.GetMonitors;
         _getMainMonitor = platform.GetMainMonitor;
+        _getDpiScale = TryGetGlfwMonitorContentScale;
     }
 
     public SilkNetWpfMonitorService(
@@ -150,6 +152,42 @@ public sealed class SilkNetWpfMonitorService : IWpfMonitorService
         catch (Exception exception)
         {
             throw new PlatformNotSupportedException("Silk.NET monitor enumeration is not available on this platform.", exception);
+        }
+    }
+
+    private static unsafe double? TryGetGlfwMonitorContentScale(IMonitor monitor)
+    {
+        ArgumentNullException.ThrowIfNull(monitor);
+
+        try
+        {
+            Glfw glfw = GlfwProvider.GLFW.Value;
+            Silk.NET.GLFW.Monitor** nativeMonitors = glfw.GetMonitors(out int monitorCount);
+            if (nativeMonitors == null || monitor.Index < 0 || monitor.Index >= monitorCount)
+            {
+                return null;
+            }
+
+            glfw.GetMonitorContentScale(nativeMonitors[monitor.Index], out float scaleX, out float scaleY);
+            return SilkNetGlfwDpiService.TryNormalizeContentScale(scaleX, scaleY, out WpfDeviceScale scale)
+                ? scale.Average
+                : null;
+        }
+        catch (DllNotFoundException)
+        {
+            return null;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+        catch (GlfwException)
+        {
+            return null;
         }
     }
 }

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -48,6 +48,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private IWpfDragDropService? _attachedDragDropService;
     private IDisposable? _windowEventSubscription;
     private IWpfWindowEventService? _attachedWindowEventService;
+    private IDisposable? _nativeDpiSubscription;
     private IWpfDispatcherService? _attachedDispatcherService;
     private IWpfPlatformServices _platformServices = CrossPlatformWpfPlatformServices.Instance;
     private IWpfRenderScheduler _wpfRenderScheduler;
@@ -79,6 +80,10 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private bool _forceFullWpfReplay;
     private bool _isHostVisible;
     private bool _hasNativeWindowCloseStarted;
+    private bool _dpiWindowHintsConfigured;
+    private bool _hasPendingNativeDpiChange;
+    private double _nativeWindowContentScaleX = double.NaN;
+    private double _nativeWindowContentScaleY = double.NaN;
     private ProGpuWpfWindowState _windowState;
     private string _windowTitle;
     private int _clientWidth;
@@ -1131,6 +1136,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
 
         if (window != null && !deferNativeWindowDispose)
         {
+            DetachNativeDpiService();
             window.Load -= OnLoad;
             window.Update -= OnUpdate;
             window.Render -= OnRender;
@@ -1188,6 +1194,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         window.Resize -= OnResize;
         window.FramebufferResize -= OnFramebufferResize;
         window.Closing -= OnClosing;
+        DetachNativeDpiService();
         window.Dispose();
         _window = null;
     }
@@ -1241,6 +1248,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         }
 
         _window = Window.Create(windowOptions);
+        _dpiWindowHintsConfigured = SilkNetGlfwDpiService.TryConfigureDpiWindowHints();
         _windowController = new SilkWindowController(_window);
         ApplyWindowBorderToController();
         _hasNativeWindowCloseStarted = false;
@@ -1254,6 +1262,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
 
     private void OnLoad()
     {
+        AttachNativeDpiService();
         _windowController?.Attach();
         EnsureCompositionTargetLoaded();
     }
@@ -1376,8 +1385,12 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         else
         {
             var framebufferSize = _window.FramebufferSize;
-            var monitorDpiScale = ResolveCurrentMonitorDpiScale();
-            UpdateClientSizeFromNativeResize(size, framebufferSize, monitorDpiScale);
+            WpfDeviceScale contentScale = ResolveCurrentWindowContentScale();
+            UpdateClientSizeFromNativeResize(
+                size,
+                framebufferSize,
+                contentScale,
+                UsesMonitorScaledWindowCoordinates());
         }
 
         if (_target == null || _window == null)
@@ -1422,6 +1435,62 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         }
     }
 
+    private void AttachNativeDpiService()
+    {
+        DetachNativeDpiService();
+        if (_window == null || _isDisposed)
+        {
+            return;
+        }
+
+        if (SilkNetGlfwDpiService.TryGetWindowContentScale(_window, out WpfDeviceScale scale))
+        {
+            CacheNativeWindowContentScale(scale);
+        }
+
+        _nativeDpiSubscription = SilkNetGlfwDpiService.TrySubscribeToWindowContentScale(
+            _window,
+            OnNativeWindowContentScaleChanged);
+    }
+
+    private void DetachNativeDpiService()
+    {
+        _nativeDpiSubscription?.Dispose();
+        _nativeDpiSubscription = null;
+        _hasPendingNativeDpiChange = false;
+        _nativeWindowContentScaleX = double.NaN;
+        _nativeWindowContentScaleY = double.NaN;
+    }
+
+    private void OnNativeWindowContentScaleChanged(WpfDeviceScale scale)
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        CacheNativeWindowContentScale(scale);
+        _hasPendingNativeDpiChange = true;
+        RequestRenderAndWakeNativeLoop();
+    }
+
+    private void CacheNativeWindowContentScale(WpfDeviceScale scale)
+    {
+        _nativeWindowContentScaleX = scale.X;
+        _nativeWindowContentScaleY = scale.Y;
+    }
+
+    private void ProcessPendingNativeDpiChange()
+    {
+        if (!_hasPendingNativeDpiChange || _window == null || _isDisposed)
+        {
+            return;
+        }
+
+        _hasPendingNativeDpiChange = false;
+        OnResize(_window.Size);
+    }
+
     private void OnUpdate(double deltaSeconds)
     {
         if (_isDisposed)
@@ -1430,6 +1499,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             return;
         }
 
+        ProcessPendingNativeDpiChange();
         TryProcessDispatcherWorkWakeup();
         UpdateTick?.Invoke(this, EventArgs.Empty);
         DisposeDeferredNativeWindowIfNeeded();
@@ -1789,15 +1859,29 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         Vector2D<int> framebufferSize,
         double monitorDpiScale)
     {
+        return ResolveRenderSurfaceGeometry(
+            clientWidth,
+            clientHeight,
+            framebufferSize,
+            new WpfDeviceScale(monitorDpiScale, monitorDpiScale));
+    }
+
+    private static RenderSurfaceGeometry ResolveRenderSurfaceGeometry(
+        int clientWidth,
+        int clientHeight,
+        Vector2D<int> framebufferSize,
+        WpfDeviceScale contentScale)
+    {
         var logicalWidth = (uint)Math.Max(1, clientWidth);
         var logicalHeight = (uint)Math.Max(1, clientHeight);
-        var fallbackScale = NormalizeMonitorDpiScale(monitorDpiScale);
+        var fallbackScaleX = NormalizeMonitorDpiScale(contentScale.X);
+        var fallbackScaleY = NormalizeMonitorDpiScale(contentScale.Y);
         var pixelWidth = framebufferSize.X > 0
             ? (uint)framebufferSize.X
-            : (uint)Math.Max(1, (int)Math.Ceiling(logicalWidth * fallbackScale));
+            : (uint)Math.Max(1, (int)Math.Ceiling(logicalWidth * fallbackScaleX));
         var pixelHeight = framebufferSize.Y > 0
             ? (uint)framebufferSize.Y
-            : (uint)Math.Max(1, (int)Math.Ceiling(logicalHeight * fallbackScale));
+            : (uint)Math.Max(1, (int)Math.Ceiling(logicalHeight * fallbackScaleY));
 
         var dpiScaleX = pixelWidth / (double)logicalWidth;
         var dpiScaleY = pixelHeight / (double)logicalHeight;
@@ -1832,18 +1916,19 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
 
         var clientSize = _window.Size;
         var framebufferSize = _window.FramebufferSize;
-        var monitorDpiScale = ResolveCurrentMonitorDpiScale();
+        WpfDeviceScale contentScale = ResolveCurrentWindowContentScale();
         var logicalSize = ResolveLogicalClientSize(
             clientSize,
             framebufferSize,
             cachedLogicalClientWidth,
             cachedLogicalClientHeight,
-            monitorDpiScale);
+            contentScale,
+            UsesMonitorScaledWindowCoordinates());
         geometry = ResolveRenderSurfaceGeometry(
             logicalSize.X,
             logicalSize.Y,
             framebufferSize,
-            monitorDpiScale);
+            contentScale);
         LastResolvedRenderSurfaceGeometry = geometry;
         return geometry;
     }
@@ -1896,12 +1981,26 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         Vector2D<int> framebufferSize,
         double monitorDpiScale)
     {
+        return UpdateClientSizeFromNativeResize(
+            size,
+            framebufferSize,
+            new WpfDeviceScale(monitorDpiScale, monitorDpiScale),
+            windowSizeIsScaledByContentScale: false);
+    }
+
+    private bool UpdateClientSizeFromNativeResize(
+        Vector2D<int> size,
+        Vector2D<int> framebufferSize,
+        WpfDeviceScale contentScale,
+        bool windowSizeIsScaledByContentScale)
+    {
         var logicalSize = ResolveLogicalClientSize(
             size,
             framebufferSize,
             GetCachedLogicalClientWidth(),
             GetCachedLogicalClientHeight(),
-            monitorDpiScale);
+            contentScale,
+            windowSizeIsScaledByContentScale);
         var clientWidth = logicalSize.X;
         var clientHeight = logicalSize.Y;
         if (_clientWidth == clientWidth && _clientHeight == clientHeight)
@@ -1966,38 +2065,69 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         int cachedHeight,
         double monitorDpiScale)
     {
+        return ResolveLogicalClientSize(
+            nativeSize,
+            framebufferSize,
+            cachedWidth,
+            cachedHeight,
+            new WpfDeviceScale(monitorDpiScale, monitorDpiScale),
+            windowSizeIsScaledByContentScale: false);
+    }
+
+    internal static Vector2D<int> ResolveLogicalClientSize(
+        Vector2D<int> nativeSize,
+        Vector2D<int> framebufferSize,
+        int cachedWidth,
+        int cachedHeight,
+        WpfDeviceScale contentScale,
+        bool windowSizeIsScaledByContentScale)
+    {
         return new Vector2D<int>(
             ResolveLogicalClientDimension(
                 nativeSize.X,
                 framebufferSize.X,
                 cachedWidth,
-                monitorDpiScale),
+                contentScale.X,
+                windowSizeIsScaledByContentScale),
             ResolveLogicalClientDimension(
                 nativeSize.Y,
                 framebufferSize.Y,
                 cachedHeight,
-                monitorDpiScale));
+                contentScale.Y,
+                windowSizeIsScaledByContentScale));
     }
 
     private static int ResolveLogicalClientDimension(
         int nativeDimension,
         int framebufferDimension,
         int cachedDimension,
-        double monitorDpiScale)
+        double contentScale,
+        bool windowSizeIsScaledByContentScale)
     {
-        // Silk.NET's IWindow.Size contract is the logical client size.  The
-        // framebuffer is the independently reported physical render surface.
-        // A previous cache/scale heuristic treated ordinary maximized sizes as
-        // physical whenever their ratio happened to resemble 1.5x, 1.75x, or
-        // 2x.  That kept stale layout bounds and offset pointer input on WSLg.
+        // Silk.NET normally exposes logical window coordinates independently
+        // from framebuffer pixels. GLFW_SCALE_TO_MONITOR is different on X11
+        // and Win32: GLFW enlarges the native content area because those
+        // platforms map window coordinates to pixels 1:1. Only divide by the
+        // authoritative GLFW content scale when that hint is active on one of
+        // those backends; ordinary Wayland/macOS and unscaled WSLg sizes remain
+        // logical and must not be inferred from a coincidental size ratio.
         if (nativeDimension > 0)
         {
+            if (windowSizeIsScaledByContentScale)
+            {
+                return Math.Max(
+                    1,
+                    (int)Math.Round(
+                        nativeDimension / NormalizeMonitorDpiScale(contentScale),
+                        MidpointRounding.AwayFromZero));
+            }
+
             return nativeDimension;
         }
 
         if (framebufferDimension > 0)
         {
-            double dpiScale = NormalizeMonitorDpiScale(monitorDpiScale);
+            double dpiScale = NormalizeMonitorDpiScale(contentScale);
             return Math.Max(
                 1,
                 (int)Math.Round(
@@ -2008,11 +2138,34 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         return Math.Max(1, cachedDimension);
     }
 
-    private double ResolveCurrentMonitorDpiScale()
+    private WpfDeviceScale ResolveCurrentWindowContentScale()
     {
-        return DisplayScaleResolver.ResolveWindowDisplayScale(
+        if (SilkNetGlfwDpiService.TryGetWindowContentScale(_window, out WpfDeviceScale nativeScale))
+        {
+            CacheNativeWindowContentScale(nativeScale);
+            return nativeScale;
+        }
+
+        if (SilkNetGlfwDpiService.TryNormalizeContentScale(
+                _nativeWindowContentScaleX,
+                _nativeWindowContentScaleY,
+                out WpfDeviceScale cachedScale))
+        {
+            return cachedScale;
+        }
+
+        double fallbackScale = DisplayScaleResolver.ResolveWindowDisplayScale(
             _window,
             ResolveCurrentMonitorDpiScaleFromPlatformServices());
+        return new WpfDeviceScale(fallbackScale, fallbackScale);
+    }
+
+    private bool UsesMonitorScaledWindowCoordinates()
+    {
+        return SilkNetGlfwDpiService.UsesMonitorScaledWindowCoordinates(
+            _dpiWindowHintsConfigured,
+            _window?.Native?.X11 is not null,
+            _window?.Native?.Win32 is not null);
     }
 
     private double ResolveCurrentMonitorDpiScaleFromPlatformServices()
@@ -2598,7 +2751,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         }
 
         TraceInputEvent("native", e);
-        var input = NormalizeInputEventForCurrentRenderSurface(e);
+        var input = NormalizeInputEventForCurrentRenderSurface(e, sender != null);
         TraceInputEvent("wpf", input);
         _isForwardingPlatformInput = true;
         try
@@ -2664,7 +2817,9 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         return Environment.GetEnvironmentVariable(environmentVariable) == "1";
     }
 
-    private WpfInputEventArgs NormalizeInputEventForCurrentRenderSurface(WpfInputEventArgs input)
+    private WpfInputEventArgs NormalizeInputEventForCurrentRenderSurface(
+        WpfInputEventArgs input,
+        bool isNativePlatformEvent)
     {
         if (!IsPointerInput(input.Kind) || _window == null)
         {
@@ -2675,8 +2830,27 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         return NormalizeInputEventForRenderSurfaceGeometry(
             input,
             geometry,
-            NativeInputCoordinatesLookPhysical(_window.Size, geometry, input),
+            NativeInputCoordinatesArePhysical(
+                isNativePlatformEvent,
+                UsesMonitorScaledWindowCoordinates(),
+                _window.Size,
+                geometry,
+                input),
             _options.NativePointerCoordinatesAreOwnerRelative);
+    }
+
+    internal static bool NativeInputCoordinatesArePhysical(
+        bool isNativePlatformEvent,
+        bool usesMonitorScaledWindowCoordinates,
+        Vector2D<int> nativeSize,
+        RenderSurfaceGeometry geometry,
+        WpfInputEventArgs input)
+    {
+        return (isNativePlatformEvent &&
+                usesMonitorScaledWindowCoordinates &&
+                geometry.DpiScale > 1.0 + double.Epsilon &&
+                IsPointerInput(input.Kind)) ||
+            NativeInputCoordinatesLookPhysical(nativeSize, geometry, input);
     }
 
     internal static WpfInputEventArgs NormalizeInputEventForRenderSurfaceGeometry(


### PR DESCRIPTION
## Summary

- enable GLFW monitor/framebuffer scaling hints and track per-window content-scale changes
- resolve X11/Win32 physical window coordinates separately from Wayland/macOS logical coordinates
- propagate portable DPI changes through HwndSource, HwndTarget, visual DPI, layout, and standard DPI events
- normalize native pointer input for scaled X11/Win32 windows while preserving logical diagnostic input
- add DPI service, geometry, input, and portable PresentationSource coverage

## Validation

- `ProGPU.Wpf.Tests` focused DPI/geometry/input tests: **23 passed**
- `ProGPU.Wpf.Tests` full assembly: **1,266 passed / 22 failed**; remaining failures are local native WebGPU library staging and pre-existing repository contract/file lookup failures
- PresentationCore unit-test project builds with the .NET 11 preview SDK; the local Linux runner cannot load its existing `UIAutomationTypes` test dependency
- Extended WPF Toolkit package-consumer app completed its full live validation at 2× DPI: **980×640 logical / 1960×1280 pixels**
- WPFGallery builds from the local LibreWPF NuGet feed and runs at 2× DPI: **1280×800 logical / 2560×1600 pixels**

## Platform notes

Linux/X11 was exercised locally. Wayland/macOS coordinate behavior is covered by backend-focused tests, but macOS was not available for an interactive run. This branch starts from the updated default branch after merging #68.