### PR TITLE
Fix mixed WPF and WinForms SDK projects

### DIFF
--- a/eng/progpu-wpf-sdk-ci.sh
+++ b/eng/progpu-wpf-sdk-ci.sh
@@ -175,6 +175,7 @@ clean_sdk_smoke_outputs() {
   for project in \
     "ProGPU.Wpf.SdkSwitchLibrary" \
     "ProGPU.Wpf.SdkSwitchSmoke" \
+    "ProGPU.Wpf.SdkMixedDesktopSmoke" \
     "ProGPU.Wpf.SdkSwitchRuntimeHarness" \
     "ProGPU.Wpf.SdkExternalSmokeHarness" \
     "ProGPU.Wpf.HelloApp" \
@@ -297,6 +298,10 @@ clean_sdk_smoke_outputs
 
 echo "Building package-mode SDK switch smoke..."
 run_dotnet build "${repo_root}/src/ProGPU.Wpf.SdkSwitchSmoke/ProGPU.Wpf.SdkSwitchSmoke.csproj" -v:minimal
+
+echo "Building and running mixed WPF/WinForms SDK smoke app..."
+run_dotnet build "${repo_root}/src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/ProGPU.Wpf.SdkMixedDesktopSmoke.csproj" -v:minimal
+run_dotnet run --no-build --project "${repo_root}/src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/ProGPU.Wpf.SdkMixedDesktopSmoke.csproj" -v:minimal
 
 echo "Running SDK switch runtime smoke..."
 run_dotnet run --project "${repo_root}/src/ProGPU.Wpf.SdkSwitchRuntimeHarness/ProGPU.Wpf.SdkSwitchRuntimeHarness.csproj" -v:minimal

--- a/packaging/ProGPU.Wpf.Sdk/Sdk/Sdk.props
+++ b/packaging/ProGPU.Wpf.Sdk/Sdk/Sdk.props
@@ -15,8 +15,6 @@
     <NoWarn>$(NoWarn);NETSDK1137</NoWarn>
     <MSBuildWarningsAsMessages Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true'">$(MSBuildWarningsAsMessages);NETSDK1106</MSBuildWarningsAsMessages>
     <ProGpuWpfUsePortablePlatform Condition="'$(ProGpuWpfUsePortablePlatform)' == ''">true</ProGpuWpfUsePortablePlatform>
-    <ProGpuWpfUsePortableWinFormsCompat Condition="'$(ProGpuWpfUsePortableWinFormsCompat)' == ''">false</ProGpuWpfUsePortableWinFormsCompat>
-    <ProGpuWpfUseLibreWinForms Condition="'$(ProGpuWpfUseLibreWinForms)' == ''">false</ProGpuWpfUseLibreWinForms>
     <ProGpuWpfEnablePortableBootstrap Condition="'$(ProGpuWpfEnablePortableBootstrap)' == ''">true</ProGpuWpfEnablePortableBootstrap>
     <ProGpuWpfUseCurrentRuntimeIdentifier Condition="'$(ProGpuWpfUseCurrentRuntimeIdentifier)' == ''">true</ProGpuWpfUseCurrentRuntimeIdentifier>
     <ProGpuWpfPlatform Condition="'$(ProGpuWpfPlatform)' == ''">SilkNet</ProGpuWpfPlatform>

--- a/packaging/ProGPU.Wpf.Sdk/Sdk/Sdk.targets
+++ b/packaging/ProGPU.Wpf.Sdk/Sdk/Sdk.targets
@@ -4,8 +4,19 @@
     <ProGpuWpfUseWpfMarkup Condition="'$(ProGpuWpfUseWpfMarkup)' == '' And '$(UseWPF)' != ''">$(UseWPF)</ProGpuWpfUseWpfMarkup>
     <ProGpuWpfUseWpfMarkup Condition="'$(ProGpuWpfUseWpfMarkup)' == ''">true</ProGpuWpfUseWpfMarkup>
     <_ProGpuWpfProjectUseWPF>$(UseWPF)</_ProGpuWpfProjectUseWPF>
+    <_ProGpuWpfProjectUseWindowsForms>$(UseWindowsForms)</_ProGpuWpfProjectUseWindowsForms>
+    <ProGpuWpfUsePortableWinFormsCompat Condition="'$(ProGpuWpfUsePortableWinFormsCompat)' == '' And '$(_ProGpuWpfProjectUseWindowsForms)' == 'true'">true</ProGpuWpfUsePortableWinFormsCompat>
+    <ProGpuWpfUsePortableWinFormsCompat Condition="'$(ProGpuWpfUsePortableWinFormsCompat)' == ''">false</ProGpuWpfUsePortableWinFormsCompat>
+    <ProGpuWpfUseLibreWinForms Condition="'$(ProGpuWpfUseLibreWinForms)' == '' And '$(_ProGpuWpfProjectUseWindowsForms)' == 'true'">true</ProGpuWpfUseLibreWinForms>
+    <ProGpuWpfUseLibreWinForms Condition="'$(ProGpuWpfUseLibreWinForms)' == ''">false</ProGpuWpfUseLibreWinForms>
     <UseWPF Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true'">false</UseWPF>
+    <UseWindowsForms Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true'">false</UseWindowsForms>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(_ProGpuWpfProjectUseWindowsForms)' == 'true' And ('$(ImplicitUsings)' == 'true' Or '$(ImplicitUsings)' == 'enable')">
+    <Using Include="System.Drawing" />
+    <Using Include="System.Windows.Forms" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(ProGpuWpfUseWpfMarkup)' == 'true'">
     <_LibreWpfPresentationBuildTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">net10.0</_LibreWpfPresentationBuildTasksTfm>

--- a/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.PortableBootstrap.cs
+++ b/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.PortableBootstrap.cs
@@ -1,27 +1,24 @@
-using System;
-using System.Runtime.CompilerServices;
-using System.Windows;
-using System.Windows.Media.ProGPU;
-
 namespace ProGPU.Wpf.Sdk;
 
 internal static class ProGpuWpfSdkPortableBootstrap
 {
-    [ModuleInitializer]
+    [global::System.Runtime.CompilerServices.ModuleInitializer]
     internal static void Initialize()
     {
 #if PROGPU_WPF_USE_LIBREWINFORMS
         global::System.Windows.Forms.Integration.WindowsFormsHost.EnableWindowsFormsInterop();
 #endif
 
-        if (OperatingSystem.IsWindows())
+        if (global::System.OperatingSystem.IsWindows())
         {
             return;
         }
 
-        RuntimeHelpers.RunModuleConstructor(typeof(Application).Module.ModuleHandle);
-        RuntimeHelpers.RunModuleConstructor(typeof(Clipboard).Module.ModuleHandle);
-        WpfPortableWindowActivation.TryRegisterPresentationFrameworkActivation();
-        WpfPortableWindowActivation.TryRegisterPresentationCoreClipboardService();
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunModuleConstructor(
+            typeof(global::System.Windows.Application).Module.ModuleHandle);
+        global::System.Runtime.CompilerServices.RuntimeHelpers.RunModuleConstructor(
+            typeof(global::System.Windows.Clipboard).Module.ModuleHandle);
+        global::System.Windows.Media.ProGPU.WpfPortableWindowActivation.TryRegisterPresentationFrameworkActivation();
+        global::System.Windows.Media.ProGPU.WpfPortableWindowActivation.TryRegisterPresentationCoreClipboardService();
     }
 }

--- a/src/ProGPU.Wpf.SdkExternalSmokeHarness/Program.cs
+++ b/src/ProGPU.Wpf.SdkExternalSmokeHarness/Program.cs
@@ -353,7 +353,10 @@ internal static class Program
         AssertContains(portableTargets, "_ProGpuWpfSdkCopyPackageRuntimeAssets", "SDK managed runtime copy target");
         AssertContains(portableTargets, "_ProGpuWpfSdkCopyNativeRuntimeAssets", "SDK native runtime copy target");
 
-        AssertContains(portableBootstrap, "[ModuleInitializer]", "SDK bootstrap module initializer");
+        AssertContains(
+            portableBootstrap,
+            "[global::System.Runtime.CompilerServices.ModuleInitializer]",
+            "SDK bootstrap module initializer");
         AssertContains(portableBootstrap, "WpfPortableWindowActivation.TryRegisterPresentationFrameworkActivation", "SDK presentation framework activation bootstrap");
         AssertContains(portableBootstrap, "WpfPortableWindowActivation.TryRegisterPresentationCoreClipboardService", "SDK presentation core clipboard bootstrap");
 

--- a/src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/ProGPU.Wpf.SdkMixedDesktopSmoke.csproj
+++ b/src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/ProGPU.Wpf.SdkMixedDesktopSmoke.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="LibreWPF.Sdk/0.1.0-preview.42">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>$(ProGpuWpfSdkSampleTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+</Project>

--- a/src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/Program.cs
+++ b/src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/Program.cs
@@ -1,0 +1,18 @@
+namespace ProGPU.Wpf.SdkMixedDesktopSmoke;
+
+internal static class Program
+{
+    [global::System.STAThread]
+    private static void Main()
+    {
+        global::System.Type wpfApplication = typeof(global::System.Windows.Application);
+        global::System.Type winFormsApplication = typeof(global::System.Windows.Forms.Application);
+        Form? implicitWinFormsType = null;
+
+        if (wpfApplication.Assembly == winFormsApplication.Assembly || implicitWinFormsType is not null)
+        {
+            throw new global::System.InvalidOperationException(
+                "The mixed desktop SDK smoke did not resolve distinct WPF and WinForms surfaces.");
+        }
+    }
+}

--- a/src/ProGPU.Wpf.SdkSwitchSmoke/ProGPU.Wpf.SdkSwitchSmoke.csproj
+++ b/src/ProGPU.Wpf.SdkSwitchSmoke/ProGPU.Wpf.SdkSwitchSmoke.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="MixedDesktop/**/*.cs" />
     <ProjectReference Include="..\ProGPU.Wpf.SdkSwitchLibrary\ProGPU.Wpf.SdkSwitchLibrary.csproj" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
   </ItemGroup>

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -14596,6 +14596,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("<TargetFramework>$(ProGpuWpfSdkSampleTargetFramework)</TargetFramework>", smokeProject, StringComparison.Ordinal);
         Assert.Contains("<RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>", smokeProject, StringComparison.Ordinal);
         Assert.Contains("<UseWPF>true</UseWPF>", smokeProject, StringComparison.Ordinal);
+        Assert.Contains("<Compile Remove=\"MixedDesktop/**/*.cs\" />", smokeProject, StringComparison.Ordinal);
         Assert.Contains(@"<ProjectReference Include=""..\ProGPU.Wpf.SdkSwitchLibrary\ProGPU.Wpf.SdkSwitchLibrary.csproj"" />", smokeProject, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"Microsoft.Xaml.Behaviors.Wpf\" Version=\"1.1.135\" />", smokeProject, StringComparison.Ordinal);
         Assert.DoesNotContain("EnableDefaultItems", smokeProject, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -11090,6 +11090,16 @@ public sealed class WpfManagedProjectGraphTests
             "src",
             "ProGPU.Wpf.SdkSwitchSmoke",
             "ProGPU.Wpf.SdkSwitchSmoke.csproj");
+        var mixedDesktopSmokeProjectPath = FindRepoPath(
+            "src",
+            "ProGPU.Wpf.SdkSwitchSmoke",
+            "MixedDesktop",
+            "ProGPU.Wpf.SdkMixedDesktopSmoke.csproj");
+        var mixedDesktopSmokeProgramPath = FindRepoPath(
+            "src",
+            "ProGPU.Wpf.SdkSwitchSmoke",
+            "MixedDesktop",
+            "Program.cs");
         var smokeDirectoryBuildPropsPath = FindRepoPath(
             "src",
             "ProGPU.Wpf.SdkSwitchSmoke",
@@ -11862,6 +11872,8 @@ public sealed class WpfManagedProjectGraphTests
         var portableTargets = File.ReadAllText(portableTargetsPath);
         var portableBootstrap = File.ReadAllText(portableBootstrapPath);
         var smokeProject = File.ReadAllText(smokeProjectPath);
+        var mixedDesktopSmokeProject = File.ReadAllText(mixedDesktopSmokeProjectPath);
+        var mixedDesktopSmokeProgram = File.ReadAllText(mixedDesktopSmokeProgramPath);
         var smokeDirectoryBuildProps = File.ReadAllText(smokeDirectoryBuildPropsPath);
         var libraryProject = File.ReadAllText(libraryProjectPath);
         var libraryDirectoryBuildProps = File.ReadAllText(libraryDirectoryBuildPropsPath);
@@ -12562,11 +12574,14 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("Running real WPF Fluent theme runtime harness", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("src/ProGPU.Wpf.RealThemeRuntimeHarness/ProGPU.Wpf.RealThemeRuntimeHarness.csproj", validationGraphs, StringComparison.Ordinal);
         Assert.Contains("src/ProGPU.Wpf.RealThemeRuntimeHarness/ProGPU.Wpf.RealThemeRuntimeHarness.csproj\" -c Release -v:minimal", sdkCiScript, StringComparison.Ordinal);
-        Assert.Equal(7, sdkCiScript.Split("run --no-build --project", StringSplitOptions.None).Length - 1);
+        Assert.Equal(8, sdkCiScript.Split("run --no-build --project", StringSplitOptions.None).Length - 1);
         Assert.Contains("packaging/Microsoft.DotNet.Wpf.GitHub/Microsoft.DotNet.Wpf.GitHub.ArchNeutral.csproj", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("src/ProGPU.Wpf/ProGPU.Wpf.csproj", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("packaging/ProGPU.Wpf.Sdk/ProGPU.Wpf.Sdk.ArchNeutral.csproj", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("src/ProGPU.Wpf.SdkSwitchSmoke/ProGPU.Wpf.SdkSwitchSmoke.csproj", sdkCiScript, StringComparison.Ordinal);
+        Assert.Contains("Building and running mixed WPF/WinForms SDK smoke app", sdkCiScript, StringComparison.Ordinal);
+        Assert.Contains("src/ProGPU.Wpf.SdkSwitchSmoke/MixedDesktop/ProGPU.Wpf.SdkMixedDesktopSmoke.csproj", sdkCiScript, StringComparison.Ordinal);
+        Assert.Contains("ProGPU.Wpf.SdkMixedDesktopSmoke", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("src/ProGPU.Wpf.SdkSwitchRuntimeHarness/ProGPU.Wpf.SdkSwitchRuntimeHarness.csproj", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("src/ProGPU.Wpf.SdkExternalSmokeHarness/ProGPU.Wpf.SdkExternalSmokeHarness.csproj", sdkCiScript, StringComparison.Ordinal);
         Assert.Contains("artifacts/nuget/ProGPU.Wpf.SdkSwitchSmoke", sdkCiScript, StringComparison.Ordinal);
@@ -14377,7 +14392,16 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("ProGPU WPF MVP quickcheck succeeded.", mvpQuickCheckScript, StringComparison.Ordinal);
 
         Assert.Contains("<_ProGpuWpfProjectUseWPF>$(UseWPF)</_ProGpuWpfProjectUseWPF>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<_ProGpuWpfProjectUseWindowsForms>$(UseWindowsForms)</_ProGpuWpfProjectUseWindowsForms>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<ProGpuWpfUsePortableWinFormsCompat Condition=\"'$(ProGpuWpfUsePortableWinFormsCompat)' == '' And '$(_ProGpuWpfProjectUseWindowsForms)' == 'true'\">true</ProGpuWpfUsePortableWinFormsCompat>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<ProGpuWpfUsePortableWinFormsCompat Condition=\"'$(ProGpuWpfUsePortableWinFormsCompat)' == ''\">false</ProGpuWpfUsePortableWinFormsCompat>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<ProGpuWpfUseLibreWinForms Condition=\"'$(ProGpuWpfUseLibreWinForms)' == '' And '$(_ProGpuWpfProjectUseWindowsForms)' == 'true'\">true</ProGpuWpfUseLibreWinForms>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<ProGpuWpfUseLibreWinForms Condition=\"'$(ProGpuWpfUseLibreWinForms)' == ''\">false</ProGpuWpfUseLibreWinForms>", sdkTargets, StringComparison.Ordinal);
         Assert.Contains("<UseWPF Condition=\"'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true'\">false</UseWPF>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<UseWindowsForms Condition=\"'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true'\">false</UseWindowsForms>", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<ItemGroup Condition=\"'$(_ProGpuWpfProjectUseWindowsForms)' == 'true' And ('$(ImplicitUsings)' == 'true' Or '$(ImplicitUsings)' == 'enable')\">", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<Using Include=\"System.Drawing\" />", sdkTargets, StringComparison.Ordinal);
+        Assert.Contains("<Using Include=\"System.Windows.Forms\" />", sdkTargets, StringComparison.Ordinal);
         Assert.Contains("<Import Sdk=\"Microsoft.NET.Sdk.WindowsDesktop\" Project=\"Sdk.targets\" />", sdkTargets, StringComparison.Ordinal);
         Assert.Contains("ProGPU.Wpf.Sdk.targets", sdkTargets, StringComparison.Ordinal);
 
@@ -14549,16 +14573,18 @@ public sealed class WpfManagedProjectGraphTests
 
         Assert.Contains("namespace ProGPU.Wpf.Sdk;", portableBootstrap, StringComparison.Ordinal);
         Assert.Contains("internal static class ProGpuWpfSdkPortableBootstrap", portableBootstrap, StringComparison.Ordinal);
-        Assert.Contains("[ModuleInitializer]", portableBootstrap, StringComparison.Ordinal);
+        Assert.Contains("[global::System.Runtime.CompilerServices.ModuleInitializer]", portableBootstrap, StringComparison.Ordinal);
         Assert.Contains("#if PROGPU_WPF_USE_LIBREWINFORMS", portableBootstrap, StringComparison.Ordinal);
         Assert.Contains("global::System.Windows.Forms.Integration.WindowsFormsHost.EnableWindowsFormsInterop();", portableBootstrap, StringComparison.Ordinal);
-        Assert.Contains("if (OperatingSystem.IsWindows())", portableBootstrap, StringComparison.Ordinal);
+        Assert.Contains("if (global::System.OperatingSystem.IsWindows())", portableBootstrap, StringComparison.Ordinal);
         Assert.True(
             portableBootstrap.IndexOf("global::System.Windows.Forms.Integration.WindowsFormsHost.EnableWindowsFormsInterop();", StringComparison.Ordinal)
-                < portableBootstrap.IndexOf("if (OperatingSystem.IsWindows())", StringComparison.Ordinal),
+                < portableBootstrap.IndexOf("if (global::System.OperatingSystem.IsWindows())", StringComparison.Ordinal),
             "LibreWinForms interop must initialize before the Windows early return.");
-        Assert.Contains("WpfPortableWindowActivation.TryRegisterPresentationFrameworkActivation()", portableBootstrap, StringComparison.Ordinal);
-        Assert.Contains("WpfPortableWindowActivation.TryRegisterPresentationCoreClipboardService()", portableBootstrap, StringComparison.Ordinal);
+        Assert.Contains("typeof(global::System.Windows.Application).Module.ModuleHandle", portableBootstrap, StringComparison.Ordinal);
+        Assert.Contains("typeof(global::System.Windows.Clipboard).Module.ModuleHandle", portableBootstrap, StringComparison.Ordinal);
+        Assert.Contains("global::System.Windows.Media.ProGPU.WpfPortableWindowActivation.TryRegisterPresentationFrameworkActivation()", portableBootstrap, StringComparison.Ordinal);
+        Assert.Contains("global::System.Windows.Media.ProGPU.WpfPortableWindowActivation.TryRegisterPresentationCoreClipboardService()", portableBootstrap, StringComparison.Ordinal);
         Assert.DoesNotContain("System.Reflection", portableBootstrap, StringComparison.Ordinal);
         Assert.DoesNotContain("GetMethod(", portableBootstrap, StringComparison.Ordinal);
         Assert.DoesNotContain("Activator", portableBootstrap, StringComparison.Ordinal);
@@ -14590,6 +14616,14 @@ public sealed class WpfManagedProjectGraphTests
         Assert.DoesNotContain("EnableNETAnalyzers", smokeProject, StringComparison.Ordinal);
         Assert.DoesNotContain("EnforceCodeStyleInBuild", smokeProject, StringComparison.Ordinal);
         Assert.DoesNotContain("NoWarn", smokeProject, StringComparison.Ordinal);
+        Assert.Contains("<Project Sdk=\"LibreWPF.Sdk/0.1.0-preview.42\">", mixedDesktopSmokeProject, StringComparison.Ordinal);
+        Assert.Contains("<OutputType>WinExe</OutputType>", mixedDesktopSmokeProject, StringComparison.Ordinal);
+        Assert.Contains("<ImplicitUsings>enable</ImplicitUsings>", mixedDesktopSmokeProject, StringComparison.Ordinal);
+        Assert.Contains("<UseWPF>true</UseWPF>", mixedDesktopSmokeProject, StringComparison.Ordinal);
+        Assert.Contains("<UseWindowsForms>true</UseWindowsForms>", mixedDesktopSmokeProject, StringComparison.Ordinal);
+        Assert.Contains("typeof(global::System.Windows.Application)", mixedDesktopSmokeProgram, StringComparison.Ordinal);
+        Assert.Contains("typeof(global::System.Windows.Forms.Application)", mixedDesktopSmokeProgram, StringComparison.Ordinal);
+        Assert.Contains("Form? implicitWinFormsType", mixedDesktopSmokeProgram, StringComparison.Ordinal);
         Assert.Contains(@"..\..\Directory.Build.props", smokeDirectoryBuildProps, StringComparison.Ordinal);
         Assert.Contains("<EnableNETAnalyzers>false</EnableNETAnalyzers>", smokeDirectoryBuildProps, StringComparison.Ordinal);
         Assert.Contains("<EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>", smokeDirectoryBuildProps, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- map the standard `UseWindowsForms=true` project setting to LibreWPF's portable WinForms compatibility path and published LibreWinForms packages
- prevent the WindowsDesktop SDK from requesting the Windows-only WinForms targeting pack on portable builds
- preserve the standard WinForms implicit usings while fully qualifying the injected LibreWPF bootstrap
- add a package-consumer mixed WPF/WinForms smoke app and run it in SDK CI

## Root cause

The SDK-owned portable bootstrap was compiled in the consumer's namespace/import context with short names for `Application` and `Clipboard`. WinForms implicit usings made those names ambiguous. Separately, `UseWindowsForms=true` remained enabled during WindowsDesktop target evaluation, which could request `Microsoft.WindowsDesktop.App.WindowsForms` on Linux instead of selecting LibreWinForms.

## User impact

Existing desktop projects can keep the standard:

```xml
<UseWPF>true</UseWPF>
<UseWindowsForms>true</UseWindowsForms>
```

settings when building with `LibreWPF.Sdk`. Explicit `ProGpuWpfUsePortableWinFormsCompat` and `ProGpuWpfUseLibreWinForms` overrides remain honored.

## Validation

- exact Linux package-consumer reproduction: 0 warnings, 0 errors
- resolved LibreWPF + LibreWinForms package graph; no WindowsDesktop WinForms targeting pack
- package-consumer process exits successfully
- repository mixed WPF/WinForms SDK smoke: build and run succeed
- SDK packaging contract test passes
- `bash -n eng/progpu-wpf-sdk-ci.sh`
- `git diff --check`

Fixes #48