### PR TITLE
Fix portable WPF text wrapping

### DIFF
--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml
@@ -587,13 +587,13 @@
                     </WrapPanel>
                     <xctk:WindowContainer x:Name="ToolkitChildWindowContainer"
                                           Grid.Row="1"
-                                          Height="168"
+                                          Height="200"
                                           Background="{StaticResource ToolkitSubtleBrush}"
                                           ModalBackgroundBrush="#33000000">
                       <xctk:ChildWindow x:Name="ToolkitChildWindow"
                                         Caption="Toolkit child window"
                                         Width="220"
-                                        Height="120"
+                                        Height="152"
                                         Left="18"
                                         Top="24"
                                         IsModal="True"
@@ -625,14 +625,14 @@
                     </xctk:WindowContainer>
                     <xctk:WindowContainer x:Name="ToolkitPrimitiveWindowContainer"
                                           Grid.Row="2"
-                                          Height="160"
+                                          Height="200"
                                           Margin="0,8,0,0"
                                           Background="{StaticResource ToolkitSubtleBrush}">
                       <xctk:WindowControl x:Name="ToolkitWindowControl"
                                           Caption="Toolkit window control"
                                           CaptionIcon="{StaticResource ToolIcon}"
                                           Width="228"
-                                          Height="124"
+                                          Height="160"
                                           Left="18"
                                           Top="24"
                                           CloseButtonVisibility="Visible"

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -88,6 +88,7 @@ public partial class MainWindow : Window
     private const string LiveValidationStatusPathEnvironmentVariable = "PROGPU_WPF_TOOLKIT_LIVE_VALIDATE_STATUS_PATH";
     private const int LiveValidationStartupMaxAttempts = 1200;
     private const int LiveValidationMaxAttempts = 400;
+    private const double LiveTargetRevealPadding = 48.0;
     private static readonly TimeSpan LiveValidationRetryDelay = TimeSpan.FromMilliseconds(16);
     private static readonly string[] AvalonDockThemeNames = ["Aero", "Metro", "VS2010"];
     private readonly ToolkitViewModel _viewModel = new();
@@ -4885,7 +4886,15 @@ public partial class MainWindow : Window
         Point initialCenter = target.TranslatePoint(
             new Point(Math.Max(1.0, target.ActualWidth) / 2.0, Math.Max(1.0, target.ActualHeight) / 2.0),
             this);
-        target.BringIntoView();
+        // A target at the edge of the Toolkit pane can be geometrically visible while an
+        // AvalonDock auto-hide strip still owns its input coordinate. Reveal a small area
+        // around the target so live input validation does not click through that overlay.
+        target.BringIntoView(
+            new Rect(
+                0,
+                -LiveTargetRevealPadding,
+                Math.Max(1.0, target.ActualWidth),
+                Math.Max(1.0, target.ActualHeight) + (LiveTargetRevealPadding * 2.0)));
         target.UpdateLayout();
 
         targetState =

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -88,7 +88,6 @@ public partial class MainWindow : Window
     private const string LiveValidationStatusPathEnvironmentVariable = "PROGPU_WPF_TOOLKIT_LIVE_VALIDATE_STATUS_PATH";
     private const int LiveValidationStartupMaxAttempts = 1200;
     private const int LiveValidationMaxAttempts = 400;
-    private const double LiveTargetRevealPadding = 48.0;
     private static readonly TimeSpan LiveValidationRetryDelay = TimeSpan.FromMilliseconds(16);
     private static readonly string[] AvalonDockThemeNames = ["Aero", "Metro", "VS2010"];
     private readonly ToolkitViewModel _viewModel = new();
@@ -4886,16 +4885,25 @@ public partial class MainWindow : Window
         Point initialCenter = target.TranslatePoint(
             new Point(Math.Max(1.0, target.ActualWidth) / 2.0, Math.Max(1.0, target.ActualHeight) / 2.0),
             this);
-        // A target at the edge of the Toolkit pane can be geometrically visible while an
-        // AvalonDock auto-hide strip still owns its input coordinate. Reveal a small area
-        // around the target so live input validation does not click through that overlay.
-        target.BringIntoView(
-            new Rect(
-                0,
-                -LiveTargetRevealPadding,
-                Math.Max(1.0, target.ActualWidth),
-                Math.Max(1.0, target.ActualHeight) + (LiveTargetRevealPadding * 2.0)));
+        target.BringIntoView();
         target.UpdateLayout();
+
+        // A target at the edge of the Toolkit pane can be geometrically visible while an
+        // AvalonDock auto-hide strip still owns its input coordinate. Center targets hosted
+        // by the pane before validating both the managed and retained GPU hit-test trees.
+        if (target.IsDescendantOf(ToolkitPaneScrollViewer) && ToolkitPaneScrollViewer.ViewportHeight > 0)
+        {
+            Point targetCenterInScrollViewer = target.TranslatePoint(
+                new Point(Math.Max(1.0, target.ActualWidth) / 2.0, Math.Max(1.0, target.ActualHeight) / 2.0),
+                ToolkitPaneScrollViewer);
+            double verticalDelta = targetCenterInScrollViewer.Y - (ToolkitPaneScrollViewer.ViewportHeight / 2.0);
+            if (Math.Abs(verticalDelta) > 0.5)
+            {
+                ToolkitPaneScrollViewer.ScrollToVerticalOffset(
+                    ToolkitPaneScrollViewer.VerticalOffset + verticalDelta);
+                target.UpdateLayout();
+            }
+        }
 
         targetState =
             $"{targetName}.IsVisible={target.IsVisible}, " +

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -4888,23 +4888,6 @@ public partial class MainWindow : Window
         target.BringIntoView();
         target.UpdateLayout();
 
-        // A target at the edge of the Toolkit pane can be geometrically visible while an
-        // AvalonDock auto-hide strip still owns its input coordinate. Center targets hosted
-        // by the pane before validating both the managed and retained GPU hit-test trees.
-        if (target.IsDescendantOf(ToolkitPaneScrollViewer) && ToolkitPaneScrollViewer.ViewportHeight > 0)
-        {
-            Point targetCenterInScrollViewer = target.TranslatePoint(
-                new Point(Math.Max(1.0, target.ActualWidth) / 2.0, Math.Max(1.0, target.ActualHeight) / 2.0),
-                ToolkitPaneScrollViewer);
-            double verticalDelta = targetCenterInScrollViewer.Y - (ToolkitPaneScrollViewer.ViewportHeight / 2.0);
-            if (Math.Abs(verticalDelta) > 0.5)
-            {
-                ToolkitPaneScrollViewer.ScrollToVerticalOffset(
-                    ToolkitPaneScrollViewer.VerticalOffset + verticalDelta);
-                target.UpdateLayout();
-            }
-        }
-
         targetState =
             $"{targetName}.IsVisible={target.IsVisible}, " +
             $"{targetName}.ActualSize={target.ActualWidth:0.###}x{target.ActualHeight:0.###}, " +
@@ -4960,10 +4943,8 @@ public partial class MainWindow : Window
         }
 
         state = $"GpuInputOwner={DescribeInputElement(selectedOwner)}";
-        if (selectedOwner == null || !IsInputElementWithinTarget(selectedOwner, target))
-        {
-            return false;
-        }
+        bool selectedOwnerIsWithinTarget =
+            selectedOwner != null && IsInputElementWithinTarget(selectedOwner, target);
 
         object?[] ownerBuffer = ArrayPool<object?>.Shared.Rent(GpuOwnerBufferCapacity);
         try
@@ -4980,7 +4961,7 @@ public partial class MainWindow : Window
                 return false;
             }
 
-            return true;
+            return selectedOwnerIsWithinTarget;
         }
         finally
         {

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -4943,8 +4943,10 @@ public partial class MainWindow : Window
         }
 
         state = $"GpuInputOwner={DescribeInputElement(selectedOwner)}";
-        bool selectedOwnerIsWithinTarget =
-            selectedOwner != null && IsInputElementWithinTarget(selectedOwner, target);
+        if (selectedOwner == null || !IsInputElementWithinTarget(selectedOwner, target))
+        {
+            return false;
+        }
 
         object?[] ownerBuffer = ArrayPool<object?>.Shared.Rent(GpuOwnerBufferCapacity);
         try
@@ -4961,7 +4963,7 @@ public partial class MainWindow : Window
                 return false;
             }
 
-            return selectedOwnerIsWithinTarget;
+            return true;
         }
         finally
         {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/SimpleTextLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/TextFormatting/SimpleTextLine.cs
@@ -164,6 +164,29 @@ namespace MS.Internal.TextFormatting
             {
                 if(!run.EOT && run.IdealWidth > widthLeft)
                 {
+                    // Windows delegates classification-based line breaking to native LineServices.
+                    // Keep the managed fallback scoped to platforms where that OS service is unavailable.
+                    if (!OperatingSystem.IsWindows() && pap.Wrap)
+                    {
+                        SimpleRun wrappingRun = CreatePortableWrappingRun(
+                            run,
+                            widthLeft,
+                            pap.EmergencyWrap,
+                            runs.Count != 0,
+                            PortableRunsEndAtBreakOpportunity(runs)
+                            );
+
+                        if (wrappingRun != null)
+                        {
+                            AddRun(runs, wrappingRun, ref nonHiddenLength);
+                        }
+
+                        if (runs.Count != 0)
+                        {
+                            break;
+                        }
+                    }
+
                     // linebreaking required, even simple text requires classification-based linebreaking,
                     // we'll now let LS handle this line.
                     return null;
@@ -234,6 +257,92 @@ namespace MS.Internal.TextFormatting
                 ref trailingSpaceWidth,
                 pixelsPerDip
                 ) as TextLine;
+        }
+
+        private static SimpleRun CreatePortableWrappingRun(
+            SimpleRun run,
+            int widthLeft,
+            bool emergencyWrap,
+            bool hasPreviousRuns,
+            bool previousRunsEndAtBreakOpportunity
+            )
+        {
+            if (run.TextRun is not TextCharacters || run.NominalAdvances == null || run.Length <= 0)
+            {
+                return null;
+            }
+
+            int fitLength = GetPortableCollapsedLength(run, widthLeft);
+            if (fitLength <= 0 && emergencyWrap && hasPreviousRuns)
+            {
+                return null;
+            }
+
+            int breakLength = FindLastPortableBreakOpportunity(run, fitLength);
+
+            if (breakLength <= 0 && previousRunsEndAtBreakOpportunity)
+            {
+                return null;
+            }
+
+            if (breakLength <= 0)
+            {
+                if (emergencyWrap)
+                {
+                    breakLength = Math.Max(1, fitLength);
+                }
+                else
+                {
+                    breakLength = FindFirstPortableBreakOpportunity(run, fitLength);
+                    if (breakLength <= 0)
+                    {
+                        breakLength = run.Length;
+                    }
+                }
+            }
+
+            return CreatePortableWordSlice(run, Math.Min(breakLength, run.Length));
+        }
+
+        private static bool PortableRunsEndAtBreakOpportunity(ArrayList runs)
+        {
+            for (int index = runs.Count - 1; index >= 0; --index)
+            {
+                if (runs[index] is not SimpleRun run || run.Ghost || run.Length <= 0)
+                {
+                    continue;
+                }
+
+                return run.Tab || SimpleRun.IsSpace(GetRunChar(run, run.Length - 1));
+            }
+
+            return false;
+        }
+
+        private static int FindLastPortableBreakOpportunity(SimpleRun run, int length)
+        {
+            for (int index = Math.Min(length, run.Length) - 1; index >= 0; --index)
+            {
+                if (SimpleRun.IsSpace(GetRunChar(run, index)))
+                {
+                    return index + 1;
+                }
+            }
+
+            return 0;
+        }
+
+        private static int FindFirstPortableBreakOpportunity(SimpleRun run, int startIndex)
+        {
+            for (int index = Math.Max(0, startIndex); index < run.Length; ++index)
+            {
+                if (SimpleRun.IsSpace(GetRunChar(run, index)))
+                {
+                    return index + 1;
+                }
+            }
+
+            return 0;
         }
 
         public static TextLine CreatePortableFallback(
@@ -871,7 +980,7 @@ namespace MS.Internal.TextFormatting
                 run.TextRun.Properties
                 );
 
-            return SimpleRun.CreateSimpleTextRun(
+            SimpleRun slicedRun = SimpleRun.CreateSimpleTextRun(
                 new CharacterBufferRange(textRun),
                 textRun,
                 run.Formatter,
@@ -880,6 +989,9 @@ namespace MS.Internal.TextFormatting
                 false,
                 run.PixelsPerDip
                 );
+            slicedRun?.Underline = run.Underline;
+
+            return slicedRun;
         }
 
         private static int FindTrailingWordBreak(SimpleRun run)

--- a/src/ProGPU.Wpf.RealApplicationRunHarness/Program.cs
+++ b/src/ProGPU.Wpf.RealApplicationRunHarness/Program.cs
@@ -1072,7 +1072,7 @@ internal static class Program
         AssertType(window, MainWindowTypeName, "startup window");
         AssertEqual("ProGPU WPF XAML smoke", GetProperty(window, "Title"), "window title");
         AssertEqual(420.0, GetProperty(window, "Width"), "window width");
-        AssertEqual(260.0, GetProperty(window, "Height"), "window height");
+        AssertEqual(340.0, GetProperty(window, "Height"), "window height");
 
         object content = GetProperty(window, "Content");
         AssertType(content, "System.Windows.Controls.StackPanel", "window content");
@@ -6549,7 +6549,7 @@ internal static class Program
             AssertEqual(true, typedActivation.IsVisible, "startup window visible before run");
             AssertEqual("ProGPU WPF XAML smoke", typedActivation.Title, "activated window title");
             AssertEqual(420.0, typedActivation.Width, "activated window width");
-            AssertEqual(260.0, typedActivation.Height, "activated window height");
+            AssertEqual(340.0, typedActivation.Height, "activated window height");
             AssertEqual(false, typedActivation.Topmost, "activated window topmost");
             Invoke(typedActivation.Window, "UpdateLayout");
             ValidatePostShowLoadedEvent(typedActivation.Window);

--- a/src/ProGPU.Wpf.RealPresentationFrameworkHarness/Program.cs
+++ b/src/ProGPU.Wpf.RealPresentationFrameworkHarness/Program.cs
@@ -21,13 +21,21 @@ public static class Program
     private const string PortableRenderDataSinkInterfaceTypeName = "System.Windows.Media.IPortableRenderDataDrawingContextSink";
 
     [STAThread]
-    private static int Main()
+    private static int Main(string[] args)
     {
         try
         {
             string repoRoot = FindRepoRoot();
             string presentationFrameworkPath = FindRealAssembly(repoRoot, "PresentationFramework");
             string presentationCorePath = FindRealAssembly(repoRoot, "PresentationCore");
+
+            if (args.Contains("--text-wrapping-only", StringComparer.Ordinal))
+            {
+                RunTextWrappingHarness(repoRoot, presentationFrameworkPath, presentationCorePath);
+                Console.WriteLine("Real PresentationFramework portable text wrapping smoke succeeded.");
+                return 0;
+            }
+
             RunHarness(repoRoot, presentationFrameworkPath, presentationCorePath);
             Console.WriteLine("Real PresentationFramework code-only smoke succeeded.");
             return 0;
@@ -36,6 +44,24 @@ public static class Program
         {
             Console.Error.WriteLine(ex);
             return 1;
+        }
+    }
+
+    private static void RunTextWrappingHarness(
+        string repoRoot,
+        string presentationFrameworkPath,
+        string presentationCorePath)
+    {
+        var loadContext = new WpfAssemblyLoadContext(repoRoot, presentationFrameworkPath, presentationCorePath);
+        try
+        {
+            Assembly presentationFramework = loadContext.LoadFromAssemblyPath(presentationFrameworkPath);
+            Assembly windowsBase = loadContext.LoadFromAssemblyName(new AssemblyName("WindowsBase"));
+            VerifyPortableTextWrapping(presentationFramework, windowsBase);
+        }
+        finally
+        {
+            loadContext.Unload();
         }
     }
 
@@ -85,6 +111,7 @@ public static class Program
             AssertCollectionCount(GetProperty(flowDocument, "Blocks"), expected: 1, "flow document blocks");
 
             VerifyPortableSpellerFallback(presentationFramework);
+            VerifyPortableTextWrapping(presentationFramework, windowsBase);
             RegisterPortableActivation(presentationFramework, window, out activationServiceType, out activation);
 
             using var target = ProGpuWpfCompositionTarget.CreateHeadless();
@@ -128,6 +155,61 @@ public static class Program
         object flowDocument = Create(presentationFramework, "System.Windows.Documents.FlowDocument");
         AddToCollection(GetProperty(flowDocument, "Blocks"), paragraph);
         return flowDocument;
+    }
+
+    private static void VerifyPortableTextWrapping(Assembly presentationFramework, Assembly windowsBase)
+    {
+        object textBlock = Create(presentationFramework, "System.Windows.Controls.TextBlock");
+        SetProperty(
+            textBlock,
+            "Text",
+            "Portable text wrapping keeps all gallery description text visible across multiple constrained lines.");
+        SetEnumProperty(textBlock, "TextWrapping", "Wrap");
+
+        Type sizeType = GetRequiredType(windowsBase, "System.Windows.Size");
+        object constraint = Activator.CreateInstance(sizeType, 120.0, double.PositiveInfinity)
+            ?? throw new InvalidOperationException("Failed to create the portable text wrapping measure constraint.");
+        MethodInfo measure = textBlock.GetType().GetMethod(
+            "Measure",
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { sizeType },
+            modifiers: null)
+            ?? throw new MissingMethodException(textBlock.GetType().FullName, "Measure(Size)");
+        measure.Invoke(textBlock, new[] { constraint });
+
+        int lineCount = (int)GetProperty(textBlock, "LineCount");
+        if (lineCount < 2)
+        {
+            throw new InvalidOperationException(
+                $"Expected portable wrapped TextBlock to produce multiple lines, got {lineCount}.");
+        }
+
+        MethodInfo getLine = textBlock.GetType().GetMethod(
+            "GetLine",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(int) },
+            modifiers: null)
+            ?? throw new MissingMethodException(textBlock.GetType().FullName, "GetLine(Int32)");
+        int coveredCharacters = 0;
+        for (int lineIndex = 0; lineIndex < lineCount; ++lineIndex)
+        {
+            object line = getLine.Invoke(textBlock, new object[] { lineIndex })
+                ?? throw new InvalidOperationException($"Expected wrapped TextBlock line {lineIndex} metrics.");
+            coveredCharacters += (int)GetProperty(line, "Length");
+        }
+
+        string text = (string)GetProperty(textBlock, "Text");
+        AssertEqual(text.Length, coveredCharacters, "portable wrapped TextBlock covered character count");
+
+        object desiredSize = GetProperty(textBlock, "DesiredSize");
+        double desiredWidth = (double)GetProperty(desiredSize, "Width");
+        if (desiredWidth > 120.01)
+        {
+            throw new InvalidOperationException(
+                $"Expected portable wrapped TextBlock width to stay within 120 DIPs, got {desiredWidth}.");
+        }
     }
 
     private static object CreateResourceDictionary(Assembly presentationFramework)

--- a/src/ProGPU.Wpf.RealThemeRuntimeHarness/Program.cs
+++ b/src/ProGPU.Wpf.RealThemeRuntimeHarness/Program.cs
@@ -1120,7 +1120,7 @@ internal static class Program
     private static void ValidateThemedVisualReplay(Assembly proGpuWpf, Assembly windowsBase, object window)
     {
         const uint pixelWidth = 420;
-        const uint pixelHeight = 260;
+        const uint pixelHeight = 340;
 
         object content = GetProperty(window, "Content");
 
@@ -1226,7 +1226,7 @@ internal static class Program
         AssertSame(window, GetProperty(activation, "Window"), "activation window");
         AssertEqual("ProGPU WPF XAML smoke", GetProperty(host, "Title"), "host title");
         AssertEqual(420, GetProperty(host, "Width"), "host width");
-        AssertEqual(260, GetProperty(host, "Height"), "host height");
+        AssertEqual(340, GetProperty(host, "Height"), "host height");
     }
 
     private static object Create(Assembly assembly, string typeName, params object?[] parameters)

--- a/src/ProGPU.Wpf.RealXamlCompilerHarness/MainWindow.xaml
+++ b/src/ProGPU.Wpf.RealXamlCompilerHarness/MainWindow.xaml
@@ -8,7 +8,7 @@
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
     Title="ProGPU WPF XAML smoke"
     Width="420"
-    Height="260">
+    Height="340">
     <Window.Resources>
         <CollectionViewSource
             x:Key="SortedItemsView"

--- a/src/ProGPU.Wpf.RealXamlRuntimeHarness/Program.cs
+++ b/src/ProGPU.Wpf.RealXamlRuntimeHarness/Program.cs
@@ -1093,7 +1093,7 @@ internal static class Program
         AssertType(window, "ProGPU.Wpf.RealXamlCompilerHarness.MainWindow", "main window");
         AssertEqual("ProGPU WPF XAML smoke", GetProperty(window, "Title"), "window title");
         AssertEqual(420.0, GetProperty(window, "Width"), "window width");
-        AssertEqual(260.0, GetProperty(window, "Height"), "window height");
+        AssertEqual(340.0, GetProperty(window, "Height"), "window height");
 
         object content = GetProperty(window, "Content");
         AssertType(content, "System.Windows.Controls.StackPanel", "window content");
@@ -5943,7 +5943,7 @@ internal static class Program
         AssertEqual(true, GetProperty(host, "IsVisible"), "host visible state");
         AssertEqual("ProGPU WPF XAML smoke", GetProperty(host, "Title"), "host title");
         AssertEqual(420, GetProperty(host, "Width"), "host width");
-        AssertEqual(260, GetProperty(host, "Height"), "host height");
+        AssertEqual(340, GetProperty(host, "Height"), "host height");
     }
 
     private static void ValidatePortableMessageBox(Assembly presentationFramework, object window)


### PR DESCRIPTION
## Summary

- add a non-Windows `SimpleTextLine` fallback for the native Windows LineServices line-breaking path
- preserve whitespace wrapping, `Wrap` emergency breaks, `WrapWithOverflow`, formatting-run boundaries, and underline metadata
- add a real `PresentationFramework` `TextBlock` smoke that verifies multiple lines, full character coverage, and constrained width
- enlarge fixed smoke/sample surfaces whose content now correctly occupies multiple lines

The Windows formatter path remains unchanged; the managed fallback is guarded by `!OperatingSystem.IsWindows()` and is used only where `PresentationNative` LineServices is unavailable.

## Validation

- focused real `PresentationFramework` portable text-wrapping smoke
- clean WPFGallery restore/build against rebuilt local `LibreWPF.Transport` and `LibreWPF.Sdk` packages
- GitHub Actions run #426:
  - Windows managed runtime payload
  - macOS SDK package/no-source-change and live Toolkit validation
  - Windows AnyCPU package launch
  - Linux Wayland-session XWayland input and popup smoke

Fixes #49