### PR TITLE
Fix portable ComboBox hit-test routing

### DIFF
--- a/src/ProGPU.Wpf.Tests/WpfPortablePresentationSourceBridgeTests.cs
+++ b/src/ProGPU.Wpf.Tests/WpfPortablePresentationSourceBridgeTests.cs
@@ -309,6 +309,53 @@ public sealed class WpfPortablePresentationSourceBridgeTests
     }
 
     [Fact]
+    public void GpuHitTestPointOverridePrefersDescendantOverEarlierAncestorHits()
+    {
+        using var host = new ProGpuWpfWindowHost();
+        using var target = ProGpuWpfCompositionTarget.CreateHeadless();
+        var source = new FakePortablePresentationSource();
+        var window = new FakeVisualOwner(PortableVisualOwnerKind.Window);
+        var dockManager = new FakeVisualOwner(PortableVisualOwnerKind.Content, window);
+        var autoHideArea = new FakeVisualOwner(PortableVisualOwnerKind.PointerInfrastructure, dockManager);
+        var filterTextBox = new FakeVisualOwner(PortableVisualOwnerKind.Content, dockManager);
+        var textView = new FakeVisualOwner(PortableVisualOwnerKind.Content, filterTextBox);
+        int dockManagerId = target.GpuHitTestOwnerMap.GetOrCreateId(dockManager);
+        int autoHideAreaId = target.GpuHitTestOwnerMap.GetOrCreateId(autoHideArea);
+        int textViewId = target.GpuHitTestOwnerMap.GetOrCreateId(textView);
+        var index = GpuHitTestIndex.Build(
+            [
+                GpuHitTestPrimitive.RectangleFill(
+                    dockManagerId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 3f),
+                GpuHitTestPrimitive.RectangleFill(
+                    autoHideAreaId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 2f),
+                GpuHitTestPrimitive.RectangleFill(
+                    textViewId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 1f)
+            ]);
+        InstallCompositionTarget(host, target);
+        InstallGpuHitTestCache(target, index);
+
+        Assert.True(WpfPortablePresentationSourceBridge.TryBind(host, source, out var bridge));
+        Assert.NotNull(bridge);
+
+        Assert.Same(textView, source.HitTestOverride!(10, 10));
+        Assert.Equal(
+            [dockManager, autoHideArea, textView],
+            source.HitTestAllOverride!(10, 10));
+    }
+
+    [Fact]
     public void GpuHitTestPointOverrideSkipsInputDisabledOverlayBeforeTopmostEnabledSibling()
     {
         using var host = new ProGpuWpfWindowHost();

--- a/src/ProGPU.Wpf.Tests/WpfPortablePresentationSourceBridgeTests.cs
+++ b/src/ProGPU.Wpf.Tests/WpfPortablePresentationSourceBridgeTests.cs
@@ -270,6 +270,97 @@ public sealed class WpfPortablePresentationSourceBridgeTests
     }
 
     [Fact]
+    public void GpuHitTestPointOverridePreservesTopmostSiblingOrderOverVisualDepth()
+    {
+        using var host = new ProGpuWpfWindowHost();
+        using var target = ProGpuWpfCompositionTarget.CreateHeadless();
+        var source = new FakePortablePresentationSource();
+        var window = new FakeVisualOwner(PortableVisualOwnerKind.Window);
+        var comboBox = new FakeVisualOwner(PortableVisualOwnerKind.Content, window);
+        var layout = new FakeVisualOwner(PortableVisualOwnerKind.PointerInfrastructure, comboBox);
+        var toggleButton = new FakeVisualOwner(PortableVisualOwnerKind.Content, layout);
+        var editableTextBox = new FakeVisualOwner(PortableVisualOwnerKind.Content, layout);
+        var textView = new FakeVisualOwner(PortableVisualOwnerKind.Content, editableTextBox);
+        int toggleButtonId = target.GpuHitTestOwnerMap.GetOrCreateId(toggleButton);
+        int textViewId = target.GpuHitTestOwnerMap.GetOrCreateId(textView);
+        var index = GpuHitTestIndex.Build(
+            [
+                GpuHitTestPrimitive.RectangleFill(
+                    toggleButtonId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 2f),
+                GpuHitTestPrimitive.RectangleFill(
+                    textViewId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 1f)
+            ]);
+        InstallCompositionTarget(host, target);
+        InstallGpuHitTestCache(target, index);
+
+        Assert.True(WpfPortablePresentationSourceBridge.TryBind(host, source, out var bridge));
+        Assert.NotNull(bridge);
+
+        Assert.Same(toggleButton, source.HitTestOverride!(10, 10));
+        Assert.Equal([toggleButton, textView], source.HitTestAllOverride!(10, 10));
+    }
+
+    [Fact]
+    public void GpuHitTestPointOverrideSkipsInputDisabledOverlayBeforeTopmostEnabledSibling()
+    {
+        using var host = new ProGpuWpfWindowHost();
+        using var target = ProGpuWpfCompositionTarget.CreateHeadless();
+        var source = new FakePortablePresentationSource();
+        var window = new FakeVisualOwner(PortableVisualOwnerKind.Window);
+        var comboBox = new FakeVisualOwner(PortableVisualOwnerKind.Content, window);
+        var layout = new FakeVisualOwner(PortableVisualOwnerKind.PointerInfrastructure, comboBox);
+        var disabledChevron = new FakeVisualOwner(
+            PortableVisualOwnerKind.Content,
+            layout,
+            isInputEnabled: false);
+        var toggleButton = new FakeVisualOwner(PortableVisualOwnerKind.Content, layout);
+        var editableTextBox = new FakeVisualOwner(PortableVisualOwnerKind.Content, layout);
+        var textView = new FakeVisualOwner(PortableVisualOwnerKind.Content, editableTextBox);
+        int disabledChevronId = target.GpuHitTestOwnerMap.GetOrCreateId(disabledChevron);
+        int toggleButtonId = target.GpuHitTestOwnerMap.GetOrCreateId(toggleButton);
+        int textViewId = target.GpuHitTestOwnerMap.GetOrCreateId(textView);
+        var index = GpuHitTestIndex.Build(
+            [
+                GpuHitTestPrimitive.RectangleFill(
+                    disabledChevronId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 3f),
+                GpuHitTestPrimitive.RectangleFill(
+                    toggleButtonId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 2f),
+                GpuHitTestPrimitive.RectangleFill(
+                    textViewId,
+                    new System.Numerics.Vector2(0f, 0f),
+                    new System.Numerics.Vector2(20f, 20f),
+                    System.Numerics.Vector2.Zero,
+                    zIndex: 1f)
+            ]);
+        InstallCompositionTarget(host, target);
+        InstallGpuHitTestCache(target, index);
+
+        Assert.True(WpfPortablePresentationSourceBridge.TryBind(host, source, out var bridge));
+        Assert.NotNull(bridge);
+
+        Assert.Same(toggleButton, source.HitTestOverride!(10, 10));
+        Assert.Equal(
+            [disabledChevron, toggleButton, textView],
+            source.HitTestAllOverride!(10, 10));
+    }
+
+    [Fact]
     public void PopupScopeFilterKeepsOnlyVisualOwnersFromItsPresentationSourceRoot()
     {
         var root = new FakeVisualOwner(PortableVisualOwnerKind.PointerInfrastructure);

--- a/src/ProGPU.Wpf/WpfPortablePresentationSourceBridge.cs
+++ b/src/ProGPU.Wpf/WpfPortablePresentationSourceBridge.cs
@@ -320,9 +320,33 @@ public sealed class WpfPortablePresentationSourceBridge : IDisposable
                 continue;
             }
 
-            // ProGPU returns point hits in descending Z order. Preserve that order so
-            // a shallower overlay (for example an editable ComboBox toggle button)
-            // wins over a deeper visual from an underlying sibling subtree.
+            bool hasMoreSpecificDescendant = false;
+            for (int j = 0; j < owners.Length; j++)
+            {
+                if (j == i || owners[j] == null ||
+                    !TryNormalizePointerInputOwner(owners[j]!, out object? otherOwner) ||
+                    otherOwner == null ||
+                    ReferenceEquals(normalizedOwner, otherOwner))
+                {
+                    continue;
+                }
+
+                if (IsVisualOwnerDescendantOrSelf(otherOwner, normalizedOwner))
+                {
+                    hasMoreSpecificDescendant = true;
+                    break;
+                }
+            }
+
+            if (hasMoreSpecificDescendant)
+            {
+                continue;
+            }
+
+            // Broad container and pointer-infrastructure primitives may precede a
+            // descendant hit. After removing those ancestors, preserve ProGPU's
+            // descending Z order so a ComboBox toggle still wins over the editor in
+            // its underlying sibling subtree.
             selectedOwner = normalizedOwner;
             return true;
         }

--- a/src/ProGPU.Wpf/WpfPortablePresentationSourceBridge.cs
+++ b/src/ProGPU.Wpf/WpfPortablePresentationSourceBridge.cs
@@ -305,7 +305,6 @@ public sealed class WpfPortablePresentationSourceBridge : IDisposable
     internal static bool TrySelectPointerInputOwner(ReadOnlySpan<object?> owners, out object? selectedOwner)
     {
         selectedOwner = null;
-        int selectedDepth = -1;
 
         for (int i = 0; i < owners.Length; i++)
         {
@@ -321,47 +320,14 @@ public sealed class WpfPortablePresentationSourceBridge : IDisposable
                 continue;
             }
 
-            int depth = GetVisualDepth(normalizedOwner);
-            if (depth > selectedDepth)
-            {
-                selectedOwner = normalizedOwner;
-                selectedDepth = depth;
-            }
-        }
-
-        if (selectedOwner != null)
-        {
+            // ProGPU returns point hits in descending Z order. Preserve that order so
+            // a shallower overlay (for example an editable ComboBox toggle button)
+            // wins over a deeper visual from an underlying sibling subtree.
+            selectedOwner = normalizedOwner;
             return true;
         }
 
-        object? deepestEnabledOwner = null;
-        int deepestEnabledDepth = -1;
-        for (int i = 0; i < owners.Length; i++)
-        {
-            object? owner = owners[i];
-            if (owner == null || IsTransparentPointerOverlay(owner))
-            {
-                continue;
-            }
-
-            object enabledOwner = NormalizePointerInputOwner(owner);
-            int depth = GetVisualDepth(enabledOwner);
-            if (depth > deepestEnabledDepth)
-            {
-                deepestEnabledOwner = enabledOwner;
-                deepestEnabledDepth = depth;
-            }
-        }
-
-        selectedOwner = deepestEnabledOwner;
-        return selectedOwner != null;
-    }
-
-    private static object NormalizePointerInputOwner(object owner)
-    {
-        return TryNormalizePointerInputOwner(owner, out object? normalizedOwner)
-            ? normalizedOwner!
-            : owner;
+        return false;
     }
 
     private static bool TryNormalizePointerInputOwner(object owner, out object? normalizedOwner)
@@ -376,26 +342,24 @@ public sealed class WpfPortablePresentationSourceBridge : IDisposable
         object? current = owner;
         for (int depth = 0; current != null && depth < 128; depth++)
         {
-            if (IsTransparentPointerOverlay(current))
+            // An input-disabled or explicitly transparent branch should expose the
+            // next lower Z-order hit, not promote an enabled ancestor over it.
+            if (IsTransparentPointerOverlay(current) || !IsEnabledInputOwner(current))
             {
-                current = TryGetVisualParent(current);
-                continue;
+                return false;
             }
 
-            if (IsEnabledInputOwner(current))
+            firstEnabledOwner ??= current;
+            if (IsWindowOwner(current))
             {
-                firstEnabledOwner ??= current;
-                if (IsWindowOwner(current))
-                {
-                    normalizedOwner = firstEnabledOwner;
-                    return normalizedOwner != null;
-                }
+                normalizedOwner = firstEnabledOwner;
+                return normalizedOwner != null;
+            }
 
-                if (!IsPointerInputInfrastructure(current))
-                {
-                    normalizedOwner = current;
-                    return true;
-                }
+            if (!IsPointerInputInfrastructure(current))
+            {
+                normalizedOwner = current;
+                return true;
             }
 
             current = TryGetVisualParent(current);
@@ -403,25 +367,6 @@ public sealed class WpfPortablePresentationSourceBridge : IDisposable
 
         normalizedOwner = firstEnabledOwner;
         return normalizedOwner != null;
-    }
-
-    private static int GetVisualDepth(object owner)
-    {
-        int depth = 0;
-        object? current = owner;
-        while (current != null && depth < 128)
-        {
-            object? parent = TryGetVisualParent(current);
-            if (parent == null)
-            {
-                break;
-            }
-
-            depth++;
-            current = parent;
-        }
-
-        return depth;
     }
 
     private static bool IsEnabledInputOwner(object owner)


### PR DESCRIPTION
## Summary

Fix portable WPF pointer routing for overlapping controls by combining visual-hierarchy specificity with ProGPU's topmost-first GPU hit order.

## Root cause

ProGPU's point-hit engine returns owners in descending Z order, but `WpfPortablePresentationSourceBridge.TrySelectPointerInputOwner` previously selected the normalized owner with the greatest global visual-tree depth.

In the Fluent editable `ComboBox` template, the arrow `ToggleButton` is a shallower topmost sibling over the deeper editable `TextBox` subtree. The bridge therefore routed arrow clicks to the underlying editor. The toggle did not open the dropdown, and WPF's existing open-dropdown `SelectAll()` behavior never ran.

A first-pass fix that selected the first GPU owner exposed the complementary Toolkit case: broad container and pointer-infrastructure primitives can precede a more-specific descendant such as a filter TextBox.

## Changes

- normalize the GPU hit owners and discard broad candidates that are ancestors of another valid hit;
- preserve ProGPU's descending Z order among the remaining sibling branches, so the editable ComboBox toggle wins over the underlying editor;
- skip input-disabled and transparent branches instead of promoting an enabled ancestor over a lower Z-order sibling;
- add focused headless regressions for:
  - a topmost ToggleButton above a deeper editable TextBox subtree;
  - a hit-test-invisible chevron above both controls;
  - broad DockManager/pointer-infrastructure hits above a filter TextBox descendant;
  - existing transparent-overlay handled-miss behavior.

No original WPF managed ComboBox code or WPFGallery workaround is changed.

## Validation

- `dotnet build src/ProGPU.Wpf.Tests/ProGPU.Wpf.Tests.csproj` — succeeded with 0 errors;
- all 18 `WpfPortablePresentationSourceBridgeTests` passed on Linux ARM64 with the pinned headless WebGPU runtime;
- GitHub Actions run 32132900991 passed all four jobs:
  - Windows managed runtime payload;
  - SDK package and no-source-change smoke, including Toolkit live input validation;
  - Windows AnyCPU package launch;
  - Linux Wayland-session XWayland input and popup smoke;
- `git diff --check`.

Fixes #51