### PR TITLE
Avoid recursive portable popup layout

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -4051,8 +4051,11 @@ namespace System.Windows.Controls.Primitives
 
             private static Size MeasurePortableRoot(UIElement rootElement, Size constraint)
             {
-                rootElement.InvalidateMeasure();
-                rootElement.Measure(constraint);
+                if (!rootElement.IsMeasureValid)
+                {
+                    rootElement.Measure(constraint);
+                }
+
                 return rootElement.DesiredSize;
             }
 

--- a/src/ProGPU.Wpf.Tests/Composition/PortablePopupLayoutSourceTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/PortablePopupLayoutSourceTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace ProGPU.Wpf.Tests.Composition;
+
+public sealed class PortablePopupLayoutSourceTests
+{
+    [Fact]
+    public void PortablePopupRootMeasurementDoesNotInvalidateLayout()
+    {
+        var popupPath = FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationFramework",
+            "System",
+            "Windows",
+            "Controls",
+            "Primitives",
+            "Popup.cs");
+        var popup = File.ReadAllText(popupPath);
+
+        Assert.Contains("if (!rootElement.IsMeasureValid)", popup, StringComparison.Ordinal);
+        Assert.Contains("rootElement.Measure(constraint);", popup, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "rootElement.InvalidateMeasure();\n                rootElement.Measure(constraint);",
+            popup,
+            StringComparison.Ordinal);
+    }
+
+    private static string FindRepoPath(params string[] pathSegments)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            var candidate = Path.Combine(new[] { directory.FullName }.Concat(pathSegments).ToArray());
+
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate repo file '{Path.Combine(pathSegments)}' from the test output directory.");
+    }
+}


### PR DESCRIPTION
## Summary

- stop the portable popup size probe from invalidating an already-valid measure pass
- preserve measurement when the popup root is genuinely invalid
- add a focused source regression test for the portable popup boundary

## Root cause

On Linux/X11, opening WPFGallery's `DatePicker` popup repeatedly re-entered layout until WPF's 153-iteration `TimeManager` guard threw. The non-Windows popup adapter handles `PopupRoot.LayoutUpdated` by updating the portable client size. Its size probe unconditionally called `InvalidateMeasure()` and `Measure()`, so every `LayoutUpdated` scheduled another layout/render pass even when the root was already valid and its size was unchanged.

Disabling ProGPU native popup windows did not change the failure. ProGPU receives the size only after this managed callback and already ignores unchanged integer bounds, so it cannot prevent the callback from self-invalidating. The fix therefore stays in the existing portable/non-Windows HWND replacement path; it does not change `DatePicker`, `Calendar`, or general Windows WPF behavior.

## Validation

- built `PresentationFramework.csproj` in Release from a clean worktree with .NET 11 Preview and static-graph offline restore: 0 errors
- built `ProGPU.Wpf.Tests.csproj` in Release: 0 errors
- ran `PortablePopupRootMeasurementDoesNotInvalidateLayout` in-process: pass
- verified the remote branch is exactly one commit ahead of `progpu-rendering-port` and changes only `Popup.cs` plus the focused regression test

Post-fix interactive X11 validation could not be repeated after the execution sandbox was tightened to deny access to the host display socket; the before-fix reproduction and 153-pass trace were captured before that restriction.

Fixes #54