### PR TITLE
Avoid reentrant rendering in externally pumped popup hosts

### DIFF
--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -378,18 +378,20 @@ public sealed class ProGpuWpfWindowHostTests
     }
 
     [Theory]
-    [InlineData(false, true, false, false, false, true)]
-    [InlineData(false, true, false, false, true, false)]
-    [InlineData(true, true, false, false, false, false)]
-    [InlineData(false, false, false, false, false, false)]
-    [InlineData(false, true, true, false, false, false)]
-    [InlineData(false, true, false, true, false, false)]
+    [InlineData(false, true, false, false, false, false, true)]
+    [InlineData(false, true, false, false, true, false, false)]
+    [InlineData(false, true, false, false, false, true, false)]
+    [InlineData(true, true, false, false, false, false, false)]
+    [InlineData(false, false, false, false, false, false, false)]
+    [InlineData(false, true, true, false, false, false, false)]
+    [InlineData(false, true, false, true, false, false, false)]
     public void RenderSchedulerWakeupDoesNotRenderInlineInsideOwnerLoop(
         bool isDisposed,
         bool hasWindow,
         bool isRendering,
         bool isProcessingRenderSchedulerWakeup,
         bool isNativeLoopRunning,
+        bool usesExternalNativeLoopPump,
         bool expected)
     {
         Assert.Equal(
@@ -399,7 +401,25 @@ public sealed class ProGpuWpfWindowHostTests
                 hasWindow,
                 isRendering,
                 isProcessingRenderSchedulerWakeup,
-                isNativeLoopRunning));
+                isNativeLoopRunning,
+                usesExternalNativeLoopPump));
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, false)]
+    public void ExternallyPumpedHostRendersPendingFrameBeforeNativeEvents(
+        bool usesExternalNativeLoopPump,
+        bool shouldPumpNativeRender,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ProGpuWpfWindowHost.ShouldPumpExternalNativeRenderBeforeEvents(
+                usesExternalNativeLoopPump,
+                shouldPumpNativeRender));
     }
 
     [Theory]

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -66,6 +66,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private bool _hasPortablePresentationSourceClientOrigin;
     private bool _isDisposed;
     private bool _isNativeLoopRunning;
+    private bool _usesExternalNativeLoopPump;
     private bool _isLoadingCompositionTarget;
     private bool _disposeNativeWindowWhenLoopExits;
     private bool _hasPresentedFrame;
@@ -990,6 +991,14 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         {
             DisposeDeferredNativeWindowIfNeeded();
             return;
+        }
+
+        if (ShouldPumpExternalNativeRenderBeforeEvents(
+                _usesExternalNativeLoopPump,
+                ShouldPumpNativeRender()))
+        {
+            NativeRenderPumpCount++;
+            window.DoRender();
         }
 
         window.DoEvents();
@@ -3295,7 +3304,8 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
                 window != null,
                 _isRendering,
                 _isProcessingRenderSchedulerWakeup,
-                _isNativeLoopRunning))
+                _isNativeLoopRunning,
+                _usesExternalNativeLoopPump))
         {
             return false;
         }
@@ -3339,19 +3349,31 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         bool hasWindow,
         bool isRendering,
         bool isProcessingRenderSchedulerWakeup,
-        bool isNativeLoopRunning)
+        bool isNativeLoopRunning,
+        bool usesExternalNativeLoopPump)
     {
-        // The owner loop already guarantees one render opportunity per iteration.
-        // Rendering inline from a Dispatcher/MediaContext callback while that loop
-        // is active can recursively enter SurfacePresent and indefinitely starve
-        // the WPF dispatcher during native pointer drags. Wake the owner loop and
-        // let its next iteration render after dispatcher/input processing returns.
+        // A running owner loop, and an externally pumped popup loop, each guarantee
+        // their own render opportunity. Rendering inline from a Dispatcher/MediaContext
+        // callback can recursively enter SurfacePresent and indefinitely starve the WPF
+        // dispatcher during native pointer drags. Let the applicable loop render after
+        // dispatcher/input processing returns instead.
         return !isDisposed
             && hasWindow
             && !isRendering
             && !isProcessingRenderSchedulerWakeup
-            && !isNativeLoopRunning;
+            && !isNativeLoopRunning
+            && !usesExternalNativeLoopPump;
     }
+
+    internal void UseExternalNativeLoopPump()
+    {
+        _usesExternalNativeLoopPump = true;
+    }
+
+    internal static bool ShouldPumpExternalNativeRenderBeforeEvents(
+        bool usesExternalNativeLoopPump,
+        bool shouldPumpNativeRender) =>
+        usesExternalNativeLoopPump && shouldPumpNativeRender;
 
     private static bool IsRecoverableDispatcherRenderException(Exception exception)
     {

--- a/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
+++ b/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
@@ -139,6 +139,7 @@ internal sealed class WpfPortableNativePopupHost : IWpfPortableNativePopupHost
             WpfResourceResolver = ownerHost.WpfResourceResolver,
             WpfImageSourceAdapter = ownerHost.WpfImageSourceAdapter
         };
+        _popupHost.UseExternalNativeLoopPump();
 
         if (!_popupHost.TryBindPortablePresentationSource(source))
         {


### PR DESCRIPTION
## Summary

- mark portable native popup hosts as externally pumped
- prevent render-scheduler callbacks from submitting a popup frame inline while WPF/native input is nested
- render a pending popup frame at the start of the owner-driven pump, before native events consume the GPU hit-test cache
- cover both scheduling decisions with focused tests

## Root cause

The portable native popup owns a child `ProGpuWpfWindowHost`, but the child does not run `Run()`; its owner pumps `DoEvents()` from `UpdateTick`. Because `_isNativeLoopRunning` remained false, WPF hit-test synchronization could process a pending render inline. That nested shared-device WebGPU submission during native pointer processing and stalled in `QueueSubmit`.

Simply suppressing inline popup renders avoided the stall but could leave the first MenuItem click using a stale GPU hit-test cache. The owner-driven pump now presents pending popup work before dispatching native events, then retains the existing post-event render opportunity.

This change is confined to LibreWPF's ProGPU.Wpf integration. It does not modify upstream WPF managed code or standalone ProGPU.

## Validation

- Release build: 0 warnings, 0 errors
- 11 focused scheduler/pre-event-pump tests passed
- 4 consecutive Linux X11-on-Wayland live MVP runs passed
  - external 36-step native drag returned to dispatcher processing
  - Aero, Aero2, AeroLite, Classic, Fluent, Luna, and Royale theme transitions rendered
  - native Menu, ComboBox dropdown, and direct Popup interaction passed (1/1/1 native windows)
- full test assembly: 1,272 passed; 27 environment-only failures in the scratch worktree due to unavailable native WebGPU lookup and uninitialized source-fixture submodules
