### PR TITLE
Refresh native popup before injected diagnostics input

### DIFF
--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -509,6 +509,10 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("SelRegisterName(\"setHidesOnDeactivate:\")", silkDecorations, StringComparison.Ordinal);
         Assert.Contains("_popupHost.SetPosition(_nativeLogicalX, _nativeLogicalY);", popupHost, StringComparison.Ordinal);
         Assert.Contains("ShouldPumpEvents(_isDisposed, _isInitialized, _isVisible, _isPumping)", popupHost, StringComparison.Ordinal);
+        Assert.Contains(
+            "PumpEventsIfNeeded();\n        _popupHost.RaiseInputForDiagnostics(input);",
+            popupHost,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
+++ b/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
@@ -205,6 +205,10 @@ internal sealed class WpfPortableNativePopupHost : IWpfPortableNativePopupHost
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
         ArgumentNullException.ThrowIfNull(input);
+        // Native input is dispatched by DoEvents after its pre-event render has
+        // refreshed the GPU hit-test cache. Preserve that ordering for injected
+        // input so diagnostics exercise the same popup state as the native path.
+        PumpEventsIfNeeded();
         _popupHost.RaiseInputForDiagnostics(input);
     }
 
@@ -316,6 +320,11 @@ internal sealed class WpfPortableNativePopupHost : IWpfPortableNativePopupHost
     }
 
     private void OnOwnerUpdateTick(object? sender, EventArgs e)
+    {
+        PumpEventsIfNeeded();
+    }
+
+    private void PumpEventsIfNeeded()
     {
         if (!ShouldPumpEvents(_isDisposed, _isInitialized, _isVisible, _isPumping))
         {


### PR DESCRIPTION
## Summary

- run the guarded owner-driven native popup pump before synthetic diagnostics input
- preserve the same pre-event render ordering used by real native popup events
- keep the existing reentrancy and visibility guards
- assert the diagnostics ordering in the managed project graph tests

## Root cause

PR #78 made production native popup input safe by rendering pending popup state before native event dispatch and by preventing scheduler callbacks from submitting recursively.

The live smoke's `RaiseInputForDiagnostics` path bypassed that owner pump and forwarded synthetic input immediately. Under Xvfb with ProGPU preview.49, the first injected MenuItem click therefore read an older GPU hit-test cache and did not invoke the command (`expected 3, found 2`).

This is a LibreWPF ProGPU.Wpf diagnostics-path correction. It does not change upstream WPF managed code or standalone ProGPU.

## Validation

- exact failed PR #77 CI package reproduced locally under Xvfb before the change
- same exact package passed 14 consecutive Xvfb/X11-on-Wayland-session runs after the change
  - external 36-step native drag completed
  - all seven framework themes rendered
  - native Menu, ComboBox dropdown, and direct Popup checks passed (1/1/1)
- Release test build: 0 errors (95 existing warnings)
- six focused popup pump/source-contract tests passed
- `git diff --check` passed
