### PR TITLE
Increase MVP live-validation timeout

### DIFF
--- a/eng/run-progpu-wpf-mvp.sh
+++ b/eng/run-progpu-wpf-mvp.sh
@@ -56,7 +56,7 @@ if [[ "${PROGPU_WPF_MVP_LIVE_VALIDATE:-0}" == "1" ]]; then
   live_log="$(mktemp "${TMPDIR:-/tmp}/progpu-wpf-mvp-live.XXXXXX")"
   live_status="$(mktemp "${TMPDIR:-/tmp}/progpu-wpf-mvp-live-status.XXXXXX")"
   apphost_pid=""
-  live_validation_timeout_seconds="${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-30}"
+  live_validation_timeout_seconds="${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-60}"
   if [[ ! "${live_validation_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
     echo "Invalid PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS value '${live_validation_timeout_seconds}'." >&2
     exit 1

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -13897,7 +13897,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("PROGPU_WPF_MVP_LIVE_VALIDATE", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("PROGPU_WPF_MVP_LIVE_VALIDATE_STATUS_PATH", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS", mvpRunScript, StringComparison.Ordinal);
-        Assert.Contains("live_validation_timeout_seconds=\"${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-30}\"", mvpRunScript, StringComparison.Ordinal);
+        Assert.Contains("live_validation_timeout_seconds=\"${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-60}\"", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("live_validation_deadline=$((SECONDS + live_validation_timeout_seconds))", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("while (( SECONDS < live_validation_deadline )); do", mvpRunScript, StringComparison.Ordinal);
         Assert.DoesNotContain("for _ in {1..600}; do", mvpRunScript, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- increase the default MVP live-validation deadline from 30 to 60 seconds
- keep `PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS` as the explicit override
- update the managed project-graph contract assertion

## Root cause

The macOS MVP probe on PR #77 reached the expected final live-input state at 29.79 seconds, but the 30-second wrapper deadline terminated the process before it could report success. An unchanged rerun completed in 24.04 seconds, confirming timing variance in the diagnostics harness rather than a product regression.

## Verification

- `dotnet build src/ProGPU.Wpf.Tests/ProGPU.Wpf.Tests.csproj -v:minimal` (0 errors)
- focused `ProGpuWpfSdkProvidesSwitchOnlyPackagingSurface` test
- `bash -n eng/run-progpu-wpf-mvp.sh`
- `git diff --check`

This changes only the CI/diagnostics harness. It does not modify upstream WPF managed code or the ProGPU submodule.