### PR TITLE
Keep portable popup size limits in logical units

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -2808,8 +2808,14 @@ namespace System.Windows.Controls.Primitives
             Size limitSize;
             GetPopupRootLimits(out targetBounds, out screenBounds, out limitSize);
 
-            // Convert from popup's space to screen space
-            desiredSize = (Size)_secHelper.GetTransformToDevice().Transform((Point)desiredSize);
+            bool usesPortableLogicalScreenCoordinates = UsesPortableLogicalScreenCoordinates(_popupRoot);
+
+            // Native HWND screen bounds are expressed in device pixels. Portable screen
+            // bounds stay in logical units, matching the popup root's desired size.
+            if (!usesPortableLogicalScreenCoordinates)
+            {
+                desiredSize = (Size)_secHelper.GetTransformToDevice().Transform((Point)desiredSize);
+            }
 
             desiredSize.Width = Math.Min(desiredSize.Width, screenBounds.Width);
             desiredSize.Width = Math.Min(desiredSize.Width, limitSize.Width);
@@ -2820,8 +2826,11 @@ namespace System.Windows.Controls.Primitives
             desiredSize.Height = Math.Min(desiredSize.Height, maxHeight);
             desiredSize.Height = Math.Min(desiredSize.Height, limitSize.Height);
 
-            // Convert back from screen space to popup's space
-            desiredSize = (Size)_secHelper.GetTransformFromDevice().Transform((Point)desiredSize);
+            if (!usesPortableLogicalScreenCoordinates)
+            {
+                // Convert back from screen space to popup's space
+                desiredSize = (Size)_secHelper.GetTransformFromDevice().Transform((Point)desiredSize);
+            }
 
             return desiredSize;
         }

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -9012,6 +9012,13 @@ public sealed class WpfManagedProjectGraphTests
         AssertGuardBefore(popup, "if (!OperatingSystem.IsWindows())\n            {\n                // Portable popups share the owner's compositor surface", "SafeNativeMethods.MonitorFromRect");
         Assert.Contains("Rect sourceBounds = _secHelper.GetParentWindowRect();", popup, StringComparison.Ordinal);
         Assert.DoesNotContain("GetPortablePrimaryScreenBounds", popup, StringComparison.Ordinal);
+        Assert.Contains("bool usesPortableLogicalScreenCoordinates = UsesPortableLogicalScreenCoordinates(_popupRoot);", popup, StringComparison.Ordinal);
+        Assert.Contains("if (!usesPortableLogicalScreenCoordinates)", popup, StringComparison.Ordinal);
+        AssertGuardBefore(popup, "if (!usesPortableLogicalScreenCoordinates)", "desiredSize = (Size)_secHelper.GetTransformToDevice().Transform((Point)desiredSize);");
+        Assert.Contains(
+            "if (!usesPortableLogicalScreenCoordinates)\n            {\n                // Convert back from screen space to popup's space\n                desiredSize = (Size)_secHelper.GetTransformFromDevice().Transform((Point)desiredSize);",
+            popup,
+            StringComparison.Ordinal);
         AssertGuardBefore(popup, "if (IsPerMonitorDpiScalingActive && OperatingSystem.IsWindows())", "SafeNativeMethods.MonitorFromPoint");
         Assert.Contains("if (!OperatingSystem.IsWindows())\n                {\n                    if (position)", popup, StringComparison.Ordinal);
         Assert.Contains("if (!OperatingSystem.IsWindows())\n                {\n                    TryShowPortablePopup();", popup, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- keep popup size restriction calculations in logical units for portable presentation sources
- retain the existing device-pixel conversions for native Windows/HWND popups
- add source-contract coverage for both guarded transforms

## Root cause

Portable popup placement and owner bounds use logical screen coordinates. `Popup.RestrictSize` nevertheless transformed the desired popup size to device pixels before comparing it with those logical bounds, then transformed it back. At 200% XWayland scaling this made the available height appear half-sized and clipped WPFGallery's Edit menu.

This is limited to LibreWPF's portable OS-coordinate path. It does not change standalone ProGPU and does not alter the Windows WPF path.

## Verification

- `ProGPU.Wpf.Tests` build: 0 errors
- focused `ProGpuWpfSdkProvidesSwitchOnlyPackagingSurface` test passes
- real WPF XAML runtime, `Application.Run`, and Fluent-theme harnesses pass
- local preview.42 LibreWPF packages built against unchanged ProGPU preview.49 packages
- WPFGallery package build: 0 errors (78 existing upstream warnings)
- 200% XWayland live result: Edit popup grows from the clipped 358×558 baseline to 358×628, with `Select All` visible and no scrollbar
- File click → Edit hover: 10/10 successful cycles
- `git diff --check`

Fixes #55