### PR TITLE
Fix portable TextBox caret blinking

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsOther.cs
@@ -8,6 +8,8 @@ namespace MS.Win32
 {
     internal partial class SafeNativeMethods
     {
+        private const int DefaultCaretBlinkTimeMilliseconds = 500;
+
         [Flags]
         internal enum PlaySoundFlags
         {
@@ -57,7 +59,10 @@ namespace MS.Win32
 
             if (!OperatingSystem.IsWindows())
             {
-                return 0;
+                // GetCaretBlinkTime reports zero only when the Win32 call fails.
+                // Returning that value for a platform without user32 causes WPF's
+                // caret animation to interpret the missing API as "do not blink".
+                return DefaultCaretBlinkTimeMilliseconds;
             }
 
             return SafeNativeMethodsPrivate.GetCaretBlinkTime();

--- a/src/ProGPU.Wpf.Tests/Composition/Mil/WpfVisualTreeRendererTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/Mil/WpfVisualTreeRendererTests.cs
@@ -484,6 +484,26 @@ public sealed class WpfVisualTreeRendererTests
     }
 
     [Fact]
+    public void ReplaySubtreeFallsBackWhenRenderSizeExceedsPortableFloatRange()
+    {
+        var root = new FakePortableVisualLayoutVisual(new PortableVisualLayoutState
+        {
+            HasRenderSize = true,
+            RenderSize = new ProGPU.Wpf.Interop.PortableSize(80, double.MaxValue / 2)
+        });
+        root.Children.Add(new FakeDrawingVisual(CreateRenderData(Brushes.Green)));
+
+        var sink = new TestSink { AcceptRetainedVisualOwners = true };
+        var result = new WpfVisualTreeRenderer().ReplaySubtree(root, sink);
+
+        Assert.Empty(sink.RetainedVisualStates);
+        Assert.Single(sink.DrawRectangles);
+        Assert.Equal(2, result.VisualCount);
+        Assert.Equal(1, result.ContentCount);
+        Assert.Equal(0, result.UnsupportedVisualStateCount);
+    }
+
+    [Fact]
     public void ReplaySubtreeUsesPortableLayoutStateForClipToBoundsAndOpacityMaskBounds()
     {
         var root = new FakePortableVisualStateAndLayoutVisual(

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -6,6 +6,22 @@ namespace ProGPU.Wpf.Tests.Composition;
 public sealed class WpfManagedProjectGraphTests
 {
     [Fact]
+    public void PortableCaretBlinkFallbackIsAValidPositiveInterval()
+    {
+        var safeNativeMethods = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "Shared",
+            "MS",
+            "Win32",
+            "SafeNativeMethodsOther.cs"));
+        Assert.Contains("private const int DefaultCaretBlinkTimeMilliseconds = 500", safeNativeMethods, StringComparison.Ordinal);
+        Assert.Contains("return DefaultCaretBlinkTimeMilliseconds;", safeNativeMethods, StringComparison.Ordinal);
+        AssertGuardBefore(safeNativeMethods, "if (!OperatingSystem.IsWindows())", "SafeNativeMethodsPrivate.GetCaretBlinkTime()");
+    }
+
+    [Fact]
     public void FocusedProGpuWpfGraphAvoidsSharedOutputParallelContention()
     {
         var project = XDocument.Load(FindRepoPath(

--- a/src/ProGPU.Wpf/Composition/Mil/WpfVisualTreeRenderer.cs
+++ b/src/ProGPU.Wpf/Composition/Mil/WpfVisualTreeRenderer.cs
@@ -500,6 +500,14 @@ public sealed class WpfVisualTreeRenderer
         if (TryReadRenderSizeBounds(visual, out var bounds))
         {
             size = new Vector2((float)bounds.Width, (float)bounds.Height);
+            // WPF uses very large finite doubles as an unbounded layout sentinel.
+            // Do not narrow that sentinel to infinity: ProGPU retained visuals use
+            // their float size to build local transforms, where infinity * 0
+            // produces NaN and drops otherwise valid descendant drawing.
+            if (!float.IsFinite(size.Value.X) || !float.IsFinite(size.Value.Y))
+            {
+                return false;
+            }
         }
 
         state = new WpfRetainedVisualState(


### PR DESCRIPTION
Fixes #58.

## What changed

- return a valid 500 ms caret blink interval when the Win32 `GetCaretBlinkTime` API is unavailable on non-Windows platforms
- reject retained ProGPU visual state when a WPF unbounded-layout sentinel cannot be represented as a finite `float`, allowing the existing non-retained replay path to preserve descendant drawing
- add focused regressions for both the portable caret interval and the oversized render-size fallback

## Root cause

Two independent portable-path assumptions hid the caret in WPFGallery:

1. the missing user32 API was represented as zero, which WPF interprets as a failed blink-time query and disables blinking
2. WPFGallery's nested TextBox layout gives `CaretSubElement` WPF's finite unbounded sentinel (`double.MaxValue / 2`). Narrowing that value into the ProGPU retained visual's `Vector2` produced infinity. ProGPU uses visual size when forming its local transform, so `infinity * 0` became NaN and the otherwise valid caret drawing was dropped

This keeps the original WPF caret/layout implementation intact. The only managed-WPF change is the fallback for a missing OS API; the representational guard belongs to LibreWPF's ProGPU WPF bridge rather than standalone ProGPU.

## Validation

- `ProGPU.Wpf.Tests.Composition.Mil.WpfVisualTreeRendererTests`: 167 passed
- portable caret fallback regression: passed
- combined focused run: 168 passed, 0 failed
- Release `LibreWPF.ProGPU` and managed transport packages rebuilt locally
- WPFGallery rebuilt from a fresh exact local-package cache; output hashes matched the rebuilt `ProGPU.Wpf.dll` and `WindowsBase.dll`
- live Linux WPFGallery TextBox accepted input and alternated between caret-visible and caret-hidden pixel states on the expected cadence