### PR TITLE
Fix portable Comic Sans font fallback

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/PortableTextInterface.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/MS/internal/Text/TextInterface/PortableTextInterface.cs
@@ -488,6 +488,7 @@ namespace MS.Internal.Text.TextInterface
             ("Calibri", new[] { "Arial", "Helvetica Neue", "Helvetica", "SF Pro Text", ".SF NS Text", "Roboto", "Liberation Sans", "DejaVu Sans", "Noto Sans" }),
             ("Cambria", new[] { "Georgia", "Times New Roman", "Times", "Liberation Serif", "DejaVu Serif", "Noto Serif" }),
             ("Consolas", new[] { "Menlo", "Monaco", "Courier New", "Courier", "Liberation Mono", "DejaVu Sans Mono", "Noto Sans Mono" }),
+            ("Comic Sans MS", new[] { "Comic Sans MS", "Comic Sans", "Comic Relief", "Chilanka", "URW Chancery L", "Z003", "Arial", "Helvetica Neue", "Helvetica", "Roboto", "Liberation Sans", "DejaVu Sans", "Noto Sans" }),
             ("Courier New", new[] { "Courier New", "Courier", "Menlo", "Monaco", "Liberation Mono", "DejaVu Sans Mono", "Noto Sans Mono" }),
             ("Microsoft Sans Serif", new[] { "Arial", "Helvetica Neue", "Helvetica", "SF Pro Text", ".SF NS Text", "Roboto", "Liberation Sans", "DejaVu Sans", "Noto Sans" }),
             ("Tahoma", new[] { "Arial", "Helvetica Neue", "Helvetica", "SF Pro Text", ".SF NS Text", "Roboto", "Liberation Sans", "DejaVu Sans", "Noto Sans" }),

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/MS/Internal/Text/TextInterface/PortableFontCollectionTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationCore.Tests/MS/Internal/Text/TextInterface/PortableFontCollectionTests.cs
@@ -32,6 +32,17 @@ public sealed class PortableFontCollectionTests
         Assert.Same(arial, collection[index]);
     }
 
+    [Fact]
+    public void ComicSansAliasResolvesPortableScriptFamilyWhenComicSansIsMissing()
+    {
+        FontFamily portableScript = CreateFamily("Z003");
+        FontFamily portableSans = CreateFamily("DejaVu Sans");
+        FontCollection collection = new(new[] { portableSans, portableScript });
+
+        Assert.True(collection.FindFamilyName("Comic Sans MS", out uint index));
+        Assert.Same(portableScript, collection[index]);
+    }
+
     private static FontFamily CreateFamily(string name)
     {
         LocalizedStrings names = new()

--- a/src/ProGPU.Wpf.Tests/Composition/WpfPortableTextInterfaceTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfPortableTextInterfaceTests.cs
@@ -24,6 +24,7 @@ public sealed class WpfPortableTextInterfaceTests
         Assert.Contains("FontCollection.FromFontSources(fontSources)", source, StringComparison.Ordinal);
         Assert.Contains("s_portableFamilyAliases", source, StringComparison.Ordinal);
         Assert.Contains("(\"Calibri\", new[]", source, StringComparison.Ordinal);
+        Assert.Contains("(\"Comic Sans MS\", new[]", source, StringComparison.Ordinal);
         Assert.Contains("(\"Segoe UI\", new[]", source, StringComparison.Ordinal);
         Assert.Contains("(\"Consolas\", new[]", source, StringComparison.Ordinal);
         Assert.Contains("TryFindFamilyName(candidate, out index)", source, StringComparison.Ordinal);


### PR DESCRIPTION
Fixes #59.

## Summary

- add portable font-family aliases for `Comic Sans MS`
- prefer installed compatible script faces before common sans-serif fallbacks
- preserve exact installed Comic Sans when available
- add focused managed font-selection and ProGPU/WPF boundary coverage

The failure occurs before ProGPU rendering: on Linux the unavailable family produced no WPF glyph run. This change stays in LibreWPF's portable OS font-substitution layer; no upstream sample code or ProGPU submodule change is needed.

## Validation

- `PortableFontCollectionTests`: 3 passed
- `WpfPortableTextInterfaceTests`: 1 passed
- release managed transport build succeeded
- local `LibreWPF.Transport.0.1.0-preview.42.nupkg` rebuilt
- WPFGallery rebuilt without source changes and the previously blank styled TextBlock row renders
- packaged and consumed `PresentationCore.dll` SHA-256 match exactly