### PR TITLE
Add portable RichTextBox layout fallback

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxLine.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxLine.cs
@@ -11,6 +11,7 @@ using System.Windows.Documents;
 using System.Windows.Media;
 using System.Windows.Media.TextFormatting;
 using MS.Internal;
+using MS.Internal.Documents;
 using MS.Internal.Text;
 
 namespace System.Windows.Controls
@@ -78,10 +79,23 @@ namespace System.Windows.Controls
                     break;
 
                 case TextPointerContext.ElementStart:
+                    Invariant.Assert(_owner.Host is RichTextBox, "Element edges are only supported for the portable RichTextBox view.");
+                    run = position.GetAdjacentElement(LogicalDirection.Forward) is LineBreak
+                        ? new TextEndOfLine(2)
+                        : new TextHidden(1);
+                    break;
+
                 case TextPointerContext.ElementEnd:
+                    Invariant.Assert(_owner.Host is RichTextBox, "Element edges are only supported for the portable RichTextBox view.");
+                    run = position.GetAdjacentElement(LogicalDirection.Forward) is Block &&
+                          position.CreatePointer(1).GetPointerContext(LogicalDirection.Forward) != TextPointerContext.None
+                        ? new TextEndOfLine(1)
+                        : new TextHidden(1);
+                    break;
+
                 case TextPointerContext.EmbeddedElement:
-                default:
-                    Invariant.Assert(false, "Unsupported position type.");
+                    Invariant.Assert(_owner.Host is RichTextBox, "Embedded elements are only supported for the portable RichTextBox view.");
+                    run = new TextHidden(TextContainerHelper.EmbeddedObjectLength);
                     break;
             }
             Invariant.Assert(run != null, "TextRun has not been created.");
@@ -96,6 +110,32 @@ namespace System.Windows.Controls
         /// </summary>
         public override TextSpan<CultureSpecificCharacterBufferRange> GetPrecedingText(int dcp)
         {
+            if (_owner.Host is RichTextBox)
+            {
+                int nonTextLength = 0;
+                CharacterBufferRange richPrecedingText = CharacterBufferRange.Empty;
+                CultureInfo richCulture = null;
+
+                if (dcp > 0)
+                {
+                    ITextPointer position = _owner.Host.TextContainer.CreatePointerAtOffset(dcp, LogicalDirection.Backward);
+                    while (position.GetPointerContext(LogicalDirection.Backward) != TextPointerContext.Text &&
+                           position.CompareTo(_owner.Host.TextContainer.Start) != 0)
+                    {
+                        position.MoveByOffset(-1);
+                        nonTextLength++;
+                    }
+
+                    string precedingTextString = position.GetTextInRun(LogicalDirection.Backward);
+                    richPrecedingText = new CharacterBufferRange(precedingTextString, 0, precedingTextString.Length);
+                    richCulture = DynamicPropertyReader.GetCultureInfo(position.CreateStaticPointer().Parent ?? (Control)_owner.Host);
+                }
+
+                return new TextSpan<CultureSpecificCharacterBufferRange>(
+                    nonTextLength + richPrecedingText.Length,
+                    new CultureSpecificCharacterBufferRange(richCulture, richPrecedingText));
+            }
+
             CharacterBufferRange precedingText = CharacterBufferRange.Empty;
             CultureInfo culture = null;
 
@@ -433,7 +473,9 @@ namespace System.Windows.Controls
             // Factor in any speller error squiggles on the run.
             TextDecorationCollection highlightDecorations = highlights.GetHighlightValue(position, LogicalDirection.Forward, typeof(SpellerHighlightLayer)) as TextDecorationCollection;
 
-            TextRunProperties properties = _lineProperties.DefaultTextRunProperties;
+            TextRunProperties properties = _owner.Host is RichTextBox
+                ? new TextProperties(position.Parent ?? (Control)_owner.Host, position, false, true, PixelsPerDip)
+                : _lineProperties.DefaultTextRunProperties;
 
             if (highlightDecorations != null)
             {

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/Internal/documents/TextBoxView.cs
@@ -562,6 +562,12 @@ namespace System.Windows.Controls
             else
             {
                 position = GetTextPositionFromDistance(lineIndex, point.X);
+                if (_host is RichTextBox)
+                {
+                    // Rich document tags are represented by zero-width formatter
+                    // runs. Keep mouse selection on a valid editable position.
+                    position = position.GetInsertionPosition(LogicalDirection.Forward);
+                }
                 position.Freeze();
             }
 

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RichTextBox.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/RichTextBox.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Controls
     /// </summary>
     [Localizability(LocalizationCategory.Inherit)]
     [ContentProperty("Document")]
-    public class RichTextBox : TextBoxBase, IAddChild
+    public class RichTextBox : TextBoxBase, IAddChild, ITextBoxViewHost
     {
         // -----------------------------------------------------------
         //
@@ -313,6 +313,18 @@ namespace System.Windows.Controls
         // Allocates the initial render scope for this control.
         internal override FrameworkElement CreateRenderScope()
         {
+            // PTS is provided by PresentationNative_cor3.dll and is unavailable on
+            // non-Windows platforms. Reuse the managed TextFormatter-based editor
+            // view there so the existing TextEditor keeps its caret, selection,
+            // input, and undo behavior while ProGPU renders the resulting visuals.
+            if (!OperatingSystem.IsWindows())
+            {
+                return new TextBoxView(this)
+                {
+                    OverridesDefaultStyle = true
+                };
+            }
+
             FlowDocumentView renderScope = new FlowDocumentView
             {
                 Document = this.Document
@@ -327,6 +339,10 @@ namespace System.Windows.Controls
 
             return renderScope;
         }
+
+        ITextContainer ITextBoxViewHost.TextContainer => TextContainer;
+
+        bool ITextBoxViewHost.IsTypographyDefaultValue => false;
 
         #endregion Protected Methods
 

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/Controls/RichTextBox.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/Controls/RichTextBox.Tests.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace System.Windows.Controls;
+
+public sealed class RichTextBoxTests
+{
+    [Fact]
+    public void CreateRenderScope_UsesPortableTextViewWhenPtsIsUnavailable()
+    {
+        RichTextBox richTextBox = new();
+
+        FrameworkElement renderScope = GetRenderScope(richTextBox);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Equal("MS.Internal.Documents.FlowDocumentView", renderScope.GetType().FullName);
+        }
+        else
+        {
+            Assert.Equal("System.Windows.Controls.TextBoxView", renderScope.GetType().FullName);
+            Type textViewType = typeof(RichTextBox).Assembly.GetType("System.Windows.Documents.ITextView", throwOnError: true)!;
+            Assert.Same(
+                renderScope,
+                ((IServiceProvider)renderScope).GetService(textViewType));
+        }
+    }
+
+    [Fact]
+    public void PortableRenderScope_FormatsRichRunsAndParagraphs()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        FlowDocument document = new();
+        document.Blocks.Add(new Paragraph(new Bold(new Run("First"))));
+        document.Blocks.Add(new Paragraph(new Italic(new Run("Second"))));
+        RichTextBox richTextBox = new(document);
+        FrameworkElement renderScope = GetRenderScope(richTextBox);
+
+        renderScope.Measure(new Size(300, double.PositiveInfinity));
+        renderScope.Arrange(new Rect(0, 0, 300, renderScope.DesiredSize.Height));
+
+        Assert.True(renderScope.DesiredSize.Width > 0);
+        Assert.True(renderScope.DesiredSize.Height > 0);
+        Assert.Equal(2, VisualTreeHelper.GetChildrenCount(renderScope));
+    }
+
+    private static FrameworkElement GetRenderScope(RichTextBox richTextBox)
+    {
+        MethodInfo createRenderScope = typeof(RichTextBox).GetMethod(
+            "CreateRenderScope",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (FrameworkElement)createRenderScope.Invoke(richTextBox, parameters: null)!;
+    }
+}


### PR DESCRIPTION
Closes #60.

## Summary
- use the managed TextBoxView/TextFormatter path for RichTextBox when Windows PTS is unavailable
- preserve rich run properties, paragraph boundaries, and editable hit-testing
- keep the original PresentationNative PTS path unchanged on Windows
- add focused portable render-scope and rich paragraph tests

## Validation
- PresentationFramework Release build
- focused RichTextBox tests: 2 passed
- clean WPFGallery RichTextEdit live test: typing and multi-paragraph editing render through ProGPU

No standalone ProGPU change is required: ProGPU already renders the WPF line visuals; the missing layer was WPF layout before visual creation.