### PR TITLE
Export GetActiveWindow from the Win32 compatibility shim

### DIFF
--- a/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.Win32Compat.c
+++ b/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.Win32Compat.c
@@ -53,6 +53,7 @@ typedef struct progpu_window_state
 } progpu_window_state;
 
 static progpu_window_state progpu_fake_window_states[PROGPU_FAKE_WINDOW_STATE_COUNT];
+static progpu_intptr progpu_active_window = 0;
 static progpu_intptr progpu_capture_window = 0;
 static progpu_intptr progpu_current_cursor = 0;
 static int32_t progpu_cursor_show_count = 0;
@@ -650,8 +651,14 @@ PROGPU_EXPORT int32_t CallNextHookEx(progpu_intptr hook, int32_t code, progpu_in
 
 PROGPU_EXPORT progpu_intptr SetActiveWindow(progpu_intptr window)
 {
-    (void)window;
-    return 0;
+    progpu_intptr previous = progpu_active_window;
+    progpu_active_window = window;
+    return previous;
+}
+
+PROGPU_EXPORT progpu_intptr GetActiveWindow(void)
+{
+    return progpu_active_window;
 }
 
 PROGPU_EXPORT progpu_intptr GetFocus(void)
@@ -1151,6 +1158,11 @@ PROGPU_EXPORT int32_t DestroyWindow(progpu_intptr window)
     if (progpu_capture_window == window)
     {
         progpu_capture_window = 0;
+    }
+
+    if (progpu_active_window == window)
+    {
+        progpu_active_window = 0;
     }
 
     return 1;

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -9542,6 +9542,11 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("UnregisterClassW", win32Compat, StringComparison.Ordinal);
         Assert.Contains("DefWindowProcW", win32Compat, StringComparison.Ordinal);
         Assert.Contains("SetWindowsHookEx", win32Compat, StringComparison.Ordinal);
+        Assert.Contains("PROGPU_EXPORT progpu_intptr GetActiveWindow(void)", win32Compat, StringComparison.Ordinal);
+        Assert.Contains("progpu_intptr previous = progpu_active_window;", win32Compat, StringComparison.Ordinal);
+        Assert.Contains("progpu_active_window = window;", win32Compat, StringComparison.Ordinal);
+        Assert.Contains("return progpu_active_window;", win32Compat, StringComparison.Ordinal);
+        Assert.Contains("if (progpu_active_window == window)", win32Compat, StringComparison.Ordinal);
         Assert.Contains("GetClientRect", win32Compat, StringComparison.Ordinal);
         Assert.Contains("GetCapture", win32Compat, StringComparison.Ordinal);
         Assert.Contains("SetCapture", win32Compat, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary
- export the missing `GetActiveWindow` entry point from the packaged `user32` compatibility shim
- make `SetActiveWindow` preserve Win32 return-value semantics and update process-local active-window state
- clear stale active-window state when the corresponding compatibility window is destroyed
- guard the ABI/state contract in the focused SDK graph test

This is contained to LibreWPF's OS compatibility layer. It does not change original WPF managed code and does not require a ProGPU change.

## Validation
- compiled `ProGPU.Wpf.Sdk.Win32Compat.c` as a Linux shared object
- `nm -D --defined-only` confirms both `GetActiveWindow` and `SetActiveWindow` exports
- direct shared-library validation confirms set/get/previous-value/destroy-clear behavior
- `ProGpuWpfSdkNativeCompatShimUsesPortableOutputPaths` passed
- rebuilt `LibreWPF.Sdk` package and Toolkit consumer
- packaged Toolkit `user32.dll.so` exposes both exports and passes the same state validation
- Toolkit live input/geometry probe passed at 980x640 logical / 1960x1280 pixels
- live Toolkit remained running after Alt input

Closes #66