### PR TITLE
Prepare WPF presentation for Dawn backends

### DIFF
--- a/src/ProGPU.Wpf.Tests/Composition/WgpuSurfaceTransitionContractTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WgpuSurfaceTransitionContractTests.cs
@@ -15,6 +15,20 @@ public sealed class WgpuSurfaceTransitionContractTests
         Assert.DoesNotContain("_target.Context.ReconfigureIfNeeded(pixelWidth, pixelHeight);", host, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void WpfHostUsesBackendNeutralSurfaceApiAndBalancesTextureOwnership()
+    {
+        string host = File.ReadAllText(FindRepoPath("src", "ProGPU.Wpf", "ProGpuWpfWindowHost.cs"));
+
+        Assert.Contains("_target.Context.Api.SurfaceGetCurrentTexture(", host, StringComparison.Ordinal);
+        Assert.Contains("_target.Context.Api.TextureCreateView(", host, StringComparison.Ordinal);
+        Assert.Contains("_target.Context.Api.SurfacePresent(_target.Context.Surface);", host, StringComparison.Ordinal);
+        Assert.Contains("_target.Context.Api.TextureViewRelease(targetView);", host, StringComparison.Ordinal);
+        Assert.Contains("_target.Context.Api.TextureRelease(surfaceTexture.Texture);", host, StringComparison.Ordinal);
+        Assert.DoesNotContain("_target.Context.Wgpu.SurfaceGetCurrentTexture", host, StringComparison.Ordinal);
+        Assert.DoesNotContain("_target.Context.Wgpu.SurfacePresent", host, StringComparison.Ordinal);
+    }
+
     private static string FindRepoPath(params string[] pathSegments)
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -1850,10 +1850,16 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         }
 
         var surfaceTexture = new SurfaceTexture();
-        _target.Context.Wgpu.SurfaceGetCurrentTexture(_target.Context.Surface, &surfaceTexture);
+        _target.Context.Api.SurfaceGetCurrentTexture(
+            _target.Context.Surface,
+            &surfaceTexture);
 
         if (surfaceTexture.Status != SurfaceGetCurrentTextureStatus.Success)
         {
+            if (surfaceTexture.Texture != null)
+            {
+                _target.Context.Api.TextureRelease(surfaceTexture.Texture);
+            }
             return false;
         }
 
@@ -1868,7 +1874,9 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             Aspect = TextureAspect.All
         };
 
-        var targetView = _target.Context.Wgpu.TextureCreateView(surfaceTexture.Texture, &viewDescriptor);
+        var targetView = _target.Context.Api.TextureCreateView(
+            surfaceTexture.Texture,
+            &viewDescriptor);
         try
         {
             _target.Render(
@@ -1883,14 +1891,18 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
                     ResolveGeometryViewportDimension(viewportHeight, pixelHeight)),
                 (float)dpiScale,
                 targetView);
-            _target.Context.Wgpu.SurfacePresent(_target.Context.Surface);
+            _target.Context.Api.SurfacePresent(_target.Context.Surface);
             return true;
         }
         finally
         {
             if (targetView != null)
             {
-                _target.Context.Wgpu.TextureViewRelease(targetView);
+                _target.Context.Api.TextureViewRelease(targetView);
+            }
+            if (surfaceTexture.Texture != null)
+            {
+                _target.Context.Api.TextureRelease(surfaceTexture.Texture);
             }
         }
     }


### PR DESCRIPTION
## Summary
- route WPF swapchain acquisition, view creation, presentation, and release through the backend-neutral WebGPU API
- release every acquired surface texture, including non-success acquisition paths
- advance the ProGPU submodule to the Dawn native-surface lifetime and adapter-diagnostic fixes in ProGPU #102

## Why this is a draft
The measured Linux ARM64 VM exposes only CPU Vulkan through llvmpipe. Its virgl OpenGL 4.0 and GLES 3.0 levels are below current Dawn requirements, and WebGPUSharp 0.5.5 ships a Vulkan-only Linux Dawn binary with undeclared libc++ runtime dependencies. The detailed report is in external/ProGPU/docs/DAWN_LINUX_VM_RENDERING.md.

This change removes concrete wgpu-native calls from the WPF presentation hot path and fixes native reference ownership, but intentionally does not add Dawn as a shipping WPF dependency until the runtime closure and hardware-adapter gate are resolved.

## Validation
- ProGPU.Wpf Release build: passed
- submodule ProGPU.Backend.Dawn Release build: passed, zero warnings/errors
- exact external-device diagnostics test: passed
- bounded Dawn 60-warmup/120-measured-frame smoke: all sampled acquisitions SuccessOptimal, zero measured surface reconfigurations, 115/120 scene-cache hits, normal exit at about 346 MB RSS
- new source contract was added; the test project was not restored/run in this constrained session

Depends on draft ProGPU #102.