### PR TITLE
Reduce portable startup compatibility probes

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml2006SchemaContext.cs
@@ -492,6 +492,10 @@ namespace System.Windows.Baml2006
 
             AssemblyName assemblyName = new AssemblyName(bamlAssembly.Name);
             bamlAssembly.Assembly = MS.Internal.WindowsBase.SafeSecurityHelper.GetLoadedAssembly(assemblyName);
+            if (bamlAssembly.Assembly == null && IsPortableCompatibilityAssembly(assemblyName))
+            {
+                bamlAssembly.Assembly = MS.Internal.WindowsBase.SafeSecurityHelper.GetLoadedAssemblyBySimpleName(assemblyName.Name);
+            }
             if (bamlAssembly.Assembly == null)
             {
                 byte[] publicKeyToken = assemblyName.GetPublicKeyToken();
@@ -533,6 +537,12 @@ namespace System.Windows.Baml2006
                 }
             }
             return bamlAssembly.Assembly;
+        }
+
+        private static bool IsPortableCompatibilityAssembly(AssemblyName assemblyName)
+        {
+            return !OperatingSystem.IsWindows()
+                && string.Equals(assemblyName.Name, "WindowsFormsIntegration", StringComparison.OrdinalIgnoreCase);
         }
 
         private bool MatchesLocalAssembly(string shortName, byte[] publicKeyToken)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml6Assembly.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Markup/Baml2006/Baml6Assembly.cs
@@ -42,6 +42,12 @@ namespace System.Windows.Baml2006
 
                 AssemblyName assemblyName = new AssemblyName(Name);
                 _assembly = SafeSecurityHelper.GetLoadedAssembly(assemblyName);
+                if (_assembly == null
+                    && !OperatingSystem.IsWindows()
+                    && string.Equals(assemblyName.Name, "WindowsFormsIntegration", StringComparison.OrdinalIgnoreCase))
+                {
+                    _assembly = SafeSecurityHelper.GetLoadedAssemblyBySimpleName(assemblyName.Name);
+                }
                 if (_assembly == null)
                 {
                     byte[] publicKeyToken = assemblyName.GetPublicKeyToken();

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Internal/SafeSecurityHelper.cs
@@ -124,6 +124,28 @@ namespace System.Xaml
             return null;
         }
 
+        /// <summary>
+        ///     Finds a loaded assembly by simple name without enforcing version, culture,
+        ///     or public-key-token identity.  This is intended only for explicit portable
+        ///     compatibility substitutions whose assembly identity cannot match the
+        ///     Windows framework assembly they replace.
+        /// </summary>
+        internal static Assembly GetLoadedAssemblyBySimpleName(string assemblyName)
+        {
+            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            for (int i = assemblies.Length - 1; i >= 0; i--)
+            {
+                AssemblyName currentAssemblyName = GetAssemblyName(assemblies[i]);
+                if (string.Equals(currentAssemblyName.Name, assemblyName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return assemblies[i];
+                }
+            }
+
+            return null;
+        }
+
         private static AssemblyName GetAssemblyName(Assembly assembly)
         {
             object key = assembly.IsDynamic ? (object)new WeakRefKey(assembly) : assembly;

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/BaseCompatibilityPreferences.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/BaseCompatibilityPreferences.cs
@@ -256,6 +256,11 @@ namespace System.Windows
         /// </summary>
         private static void SetMatchPackageSignatureMethodToPackagePartDigestMethodFromRegistry()
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
             try
             {
                 // Query registry for system override

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/MS/Internal/WindowsBase/SafeSecurityHelperTests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/WindowsBase.Tests/MS/Internal/WindowsBase/SafeSecurityHelperTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace MS.Internal.WindowsBase.Tests;
+
+public class SafeSecurityHelperTests
+{
+    [Fact]
+    public void GetLoadedAssemblyBySimpleName_IgnoresFrameworkIdentity()
+    {
+        Assembly currentAssembly = Assembly.GetExecutingAssembly();
+        AssemblyName requestedIdentity = new(currentAssembly.GetName().Name)
+        {
+            Version = new Version(999, 0, 0, 0),
+            CultureName = string.Empty,
+        };
+        requestedIdentity.SetPublicKeyToken(Convert.FromHexString("31BF3856AD364E35"));
+
+        SafeSecurityHelper.GetLoadedAssembly(requestedIdentity).Should().BeNull();
+        SafeSecurityHelper.GetLoadedAssemblyBySimpleName(requestedIdentity.Name).Should().BeSameAs(currentAssembly);
+    }
+
+    [Fact]
+    public void GetLoadedAssemblyBySimpleName_UnknownName_ReturnsNull()
+    {
+        SafeSecurityHelper.GetLoadedAssemblyBySimpleName($"Missing.{Guid.NewGuid():N}").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- reuse the loaded portable WindowsFormsIntegration compatibility assembly when legacy BAML requests the signed Windows framework identity
- retain exact assembly identity matching on Windows and for every other assembly
- skip the Windows registry compatibility lookup on non-Windows
- add focused coverage for simple-name lookup of an explicitly loaded compatibility assembly

## Performance evidence

An equivalent 10-second startup exception trace from a private portable WPF validation workload showed:

- WindowsFormsIntegration FileNotFoundException probes: 61 before, 0 after
- all FileNotFoundException events: 61 before, 2 after; the two remaining events are unrelated optional windowing-backend discovery
- registry-path NullReferenceException events: 1 before, 0 after

This PR deliberately makes no wall-clock speedup claim because startup timing on the 4-vCPU VM was highly variable. The measured win is removal of repeated exception-driven compatibility probes.

## Validation

- WindowsBase Release build: passed, 0 warnings, 0 errors
- PresentationFramework Release build: passed, 0 warnings, 0 errors
- private portable WPF workload: started and opened its full window with locally built assemblies
- focused test project execution: blocked on this Linux VM because its graph imports Microsoft.Cpp.Default.props and the repository currently configures Microsoft.Testing.Platform while the project uses VSTest
