### PR TITLE
Preserve grid definition initialization in composite ReadyToRun

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DefinitionBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/DefinitionBase.cs
@@ -15,6 +15,7 @@
 
 using MS.Internal;
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace System.Windows.Controls
 {
@@ -33,6 +34,9 @@ namespace System.Windows.Controls
 
         #region Constructors
 
+        // Composite ReadyToRun can otherwise inline the derived RowDefinition/ColumnDefinition
+        // constructors without preserving these non-default field assignments.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         internal DefinitionBase(bool isColumnDefinition)
         {
             _isColumnDefinition = isColumnDefinition;

--- a/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/Controls/DefinitionBase.Tests.cs
+++ b/src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/System/Windows/Controls/DefinitionBase.Tests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace System.Windows.Controls;
+
+public sealed class DefinitionBaseTests
+{
+    [Fact]
+    public void DetachedDefinitions_CanSetSizingProperties()
+    {
+        RowDefinition row = new()
+        {
+            Height = GridLength.Auto,
+            MinHeight = 1,
+            MaxHeight = 100
+        };
+        ColumnDefinition column = new()
+        {
+            Width = new GridLength(2, GridUnitType.Star),
+            MinWidth = 2,
+            MaxWidth = 200
+        };
+
+        Assert.True(row.Height.IsAuto);
+        Assert.Equal(1, row.MinHeight);
+        Assert.Equal(100, row.MaxHeight);
+        Assert.Equal(new GridLength(2, GridUnitType.Star), column.Width);
+        Assert.Equal(2, column.MinWidth);
+        Assert.Equal(200, column.MaxWidth);
+    }
+
+    [Fact]
+    public void Constructor_IsNotInlineable()
+    {
+        ConstructorInfo constructor = typeof(DefinitionBase).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(bool)],
+            modifiers: null)!;
+
+        Assert.True((constructor.MethodImplementationFlags & MethodImplAttributes.NoInlining) != 0);
+    }
+}


### PR DESCRIPTION
## Summary

- prevent composite ReadyToRun from folding the stateful `DefinitionBase` constructor into derived grid-definition constructors
- preserve the non-default parent index and row/column discriminator by making that constructor non-inlineable
- add focused coverage for detached sizing-property assignment and the R2R implementation guard

## Evidence

A headless repro creates detached `RowDefinition` and `ColumnDefinition` instances, inspects their constructor state, and assigns sizing properties.

Before this change:

- ordinary JIT: `_parentIndex = -1`, column discriminator is `true`, exits successfully
- composite R2R: `_parentIndex = 0`, column discriminator is `false`, then aborts with `NullReferenceException` in `DefinitionBase.OnUserSizePropertyChanged`

After this change, the same composite-R2R publish reports `_parentIndex = -1`, the correct column discriminator, assigns all sizing properties, and exits 0. A bounded private portable-WPF validation workload also completed main-window startup and repository refresh and remained alive for the full 15-second smoke window.

Cached startup measurements were intentionally treated as secondary: 8 alternating runs per mode produced medians of 1322 ms for JIT and 1303 ms for R2R (-1.4%), with substantial VM noise. This PR therefore makes no end-to-end performance claim; it restores correctness so R2R can be evaluated and used.

## Validation

- `dotnet build src/Microsoft.DotNet.Wpf/src/PresentationFramework/PresentationFramework.csproj -c Release --no-restore /p:UseSharedCompilation=false /p:BuildProjectReferences=false`
- `dotnet build src/Microsoft.DotNet.Wpf/tests/UnitTests/PresentationFramework.Tests/PresentationFramework.Tests.csproj -c Release --no-restore /p:UseSharedCompilation=false /p:BuildProjectReferences=false`
- focused `DefinitionBaseTests`: 2 passed
- headless framework-dependent `linux-arm64` composite-R2R publish/run: passed
- full validation-workload composite-R2R startup smoke: passed
- `git diff --check`