### PR TITLE
Honor demand-driven WPF presentation

### DIFF
--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -590,6 +590,60 @@ public sealed class ProGpuWpfWindowHostTests
     }
 
     [Fact]
+    public void MediaContextTickDoesNotPresentAnUnchangedFrame()
+    {
+        var scheduler = new TestRenderScheduler();
+        using var host = new ProGpuWpfWindowHost
+        {
+            WpfRenderScheduler = scheduler
+        };
+        var frameState = new ProGpuWpfFrameState(100, 50, 1, 2, 3);
+        host.RecordPresentedFrame(frameState);
+
+        host.RequestMediaContextRenderAndWakeNativeLoop(null, TimeSpan.Zero);
+
+        Assert.True(scheduler.HasPendingRenderRequest);
+        Assert.False(host.ShouldRenderFrame(frameState));
+        Assert.False(host.ConsumeScheduledRenderRequest());
+        Assert.False(scheduler.HasPendingRenderRequest);
+    }
+
+    [Fact]
+    public void ExplicitRenderRequestUpgradesPendingMediaContextTick()
+    {
+        var scheduler = new TestRenderScheduler();
+        using var host = new ProGpuWpfWindowHost
+        {
+            WpfRenderScheduler = scheduler
+        };
+        var frameState = new ProGpuWpfFrameState(100, 50, 1, 2, 3);
+        host.RecordPresentedFrame(frameState);
+
+        host.RequestMediaContextRenderAndWakeNativeLoop(null, TimeSpan.Zero);
+        host.RequestRenderAndWakeNativeLoop();
+
+        Assert.True(host.ShouldRenderFrame(frameState));
+        Assert.True(host.ConsumeScheduledRenderRequest());
+    }
+
+    [Fact]
+    public void MediaContextVisualInvalidationRequiresPresentation()
+    {
+        var scheduler = new TestRenderScheduler();
+        using var host = new ProGpuWpfWindowHost
+        {
+            WpfRenderScheduler = scheduler
+        };
+        var frameState = new ProGpuWpfFrameState(100, 50, 1, 2, 3);
+        host.RecordPresentedFrame(frameState);
+
+        host.RequestMediaContextRenderAndWakeNativeLoop(new object(), TimeSpan.Zero);
+
+        Assert.True(host.ShouldRenderFrame(frameState));
+        Assert.True(host.ConsumeScheduledRenderRequest());
+    }
+
+    [Fact]
     public void ShouldRenderFrameReturnsTrueWhenNativeVersionChanges()
     {
         using var host = new ProGpuWpfWindowHost();

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -77,6 +77,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private bool _disposeNativeWindowWhenLoopExits;
     private bool _hasPresentedFrame;
     private long _presentedFrameCount;
+    private int _pendingRenderRequestIsWakeOnly;
     private bool _ownsRenderScheduler;
     private bool _isRendering;
     private bool _isRenderingLiveResize;
@@ -1643,6 +1644,12 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
                 return;
             }
 
+            // Consume the request that entered this render callback before WPF
+            // processes its dispatcher queue. MediaContext can schedule the next
+            // animation tick while that queue is being drained; consuming at the
+            // end would incorrectly discard that future request.
+            bool currentRequestRequiresPresentation = ConsumeScheduledRenderRequest();
+
             var geometry = ResolveCurrentRenderSurfaceGeometry();
             SynchronizePortablePresentationSourceGeometry(geometry);
             ProcessDispatcherQueueCore();
@@ -1674,7 +1681,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
                 pixelHeight,
                 dpiScale);
 
-            if (!ShouldRenderFrame(frameState))
+            if (!ShouldRenderFrame(frameState, currentRequestRequiresPresentation))
             {
                 SkippedFrameCount++;
                 return;
@@ -1802,8 +1809,6 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
                 {
                     Render?.Invoke(this, args);
                 }
-
-                WpfRenderScheduler.ConsumeRenderRequest();
             }
 
             if (Present(
@@ -2399,10 +2404,17 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
 
     private void OnCompositionTargetRenderInvalidated(object? sender, EventArgs e)
     {
-        RequestRenderAndWakeNativeLoop();
+        RequestRenderWakeOnlyAndWakeNativeLoop();
     }
 
     internal bool ShouldRenderFrame(ProGpuWpfFrameState frameState)
+    {
+        return ShouldRenderFrame(frameState, currentRequestRequiresPresentation: false);
+    }
+
+    private bool ShouldRenderFrame(
+        ProGpuWpfFrameState frameState,
+        bool currentRequestRequiresPresentation)
     {
         if (!EnableFrameCoalescing)
         {
@@ -2414,7 +2426,9 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             return true;
         }
 
-        if (WpfRenderScheduler.HasPendingRenderRequest)
+        if (currentRequestRequiresPresentation ||
+            (WpfRenderScheduler.HasPendingRenderRequest &&
+             Volatile.Read(ref _pendingRenderRequestIsWakeOnly) == 0))
         {
             return true;
         }
@@ -3314,6 +3328,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         target.RenderInvalidated -= OnCompositionTargetRenderInvalidated;
         target.Dispose();
         WpfRenderScheduler.Reset();
+        Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 0);
         LastPresentedFrameState = default;
         Interlocked.Exchange(ref _presentedFrameCount, 0);
         Volatile.Write(ref _hasPresentedFrame, false);
@@ -3377,6 +3392,9 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
 
         try
         {
+            // Any explicit host or visual invalidation upgrades a coalesced
+            // MediaContext wakeup into a presentation request.
+            Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 0);
             WpfRenderScheduler.RequestRender();
         }
         catch (ObjectDisposedException)
@@ -3385,6 +3403,86 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         }
 
         TryRequestNativeLoopWakeup();
+    }
+
+    private void RequestRenderWakeOnlyAndWakeNativeLoop()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        try
+        {
+            // Composition-target invalidation already advances the scene state
+            // captured by ShouldRenderFrame. Schedule the host pump, but do not
+            // turn an invalidation produced while assembling the current frame
+            // into an unconditional extra presentation.
+            if (!WpfRenderScheduler.HasPendingRenderRequest)
+            {
+                Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 1);
+            }
+
+            WpfRenderScheduler.RequestRender();
+        }
+        catch (ObjectDisposedException)
+        {
+            Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 0);
+            return;
+        }
+
+        TryRequestNativeLoopWakeup();
+    }
+
+    internal void RequestMediaContextRenderAndWakeNativeLoop(
+        object? invalidatedSource,
+        TimeSpan delay)
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        if (invalidatedSource != null)
+        {
+            InvalidateWpfSourceForPortableRender(invalidatedSource);
+            RequestRenderAndWakeNativeLoop();
+            return;
+        }
+
+        try
+        {
+            // A source-less MediaContext request only wakes WPF so animation and
+            // CompositionTarget.Rendering callbacks can run. It does not imply
+            // that those callbacks changed the retained scene.
+            if (!WpfRenderScheduler.HasPendingRenderRequest)
+            {
+                Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 1);
+            }
+
+            if (WpfRenderScheduler is IWpfDelayedRenderScheduler delayedScheduler)
+            {
+                delayedScheduler.RequestRender(delay);
+            }
+            else
+            {
+                WpfRenderScheduler.RequestRender();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 0);
+            return;
+        }
+
+        TryRequestNativeLoopWakeup();
+    }
+
+    internal bool ConsumeScheduledRenderRequest()
+    {
+        bool wakeOnly = Interlocked.Exchange(ref _pendingRenderRequestIsWakeOnly, 0) != 0;
+        bool hadPendingRequest = WpfRenderScheduler.ConsumeRenderRequest();
+        return hadPendingRequest && !wakeOnly;
     }
 
     internal void InvalidateWpfSourceForPortableRender(object? source)

--- a/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
+++ b/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
@@ -1564,18 +1564,7 @@ public sealed class WpfPortableWindowActivation : IDisposable
 
         try
         {
-            Host.InvalidateWpfSourceForPortableRender(invalidatedSource ?? RootVisual);
-
-            if (Host.WpfRenderScheduler is IWpfDelayedRenderScheduler delayedScheduler)
-            {
-                delayedScheduler.RequestRender(delay);
-            }
-            else
-            {
-                Host.WpfRenderScheduler.RequestRender();
-            }
-
-            Host.TryRequestNativeLoopWakeup();
+            Host.RequestMediaContextRenderAndWakeNativeLoop(invalidatedSource, delay);
         }
         catch (ObjectDisposedException)
         {


### PR DESCRIPTION
## Summary
- distinguish source-less MediaContext tick wakeups from actual presentation requests
- consume the request that entered a frame before dispatcher processing so follow-up animation ticks are preserved
- avoid turning composition invalidations produced by the current frame into unconditional extra presentations
- preserve forced frames for real WPF invalidations, explicit host requests, resize/DPI state changes, and explicit frame callbacks

## Evidence
A private cross-platform validation workload showed source-less MediaContext wakeups being promoted to full-root invalidations. On a software WebGPU adapter, each unnecessary full-surface frame occupied the UI thread for hundreds of milliseconds. The new request provenance keeps WPF callbacks scheduled while allowing unchanged retained frame state to coalesce.

## Validation
- Release build of `ProGPU.Wpf.Tests`: succeeded (1 existing warning, 0 errors)
- focused request-provenance tests: 3 passed
- broader `ProGpuWpfWindowHostTests`: 161 passed; 5 native-GPU cases were environment-blocked because the test output did not contain a WebGPU native library
- ARM64 Linux private validation: native window mapped and closed with exit code 0

## Scope
This PR changes only the WPF host scheduling contract. Retained-branch replay conflicts and ProGPU compiled-scene caching are intentionally left for separate PRs.