### PR TITLE
Replay shared retained branches from unique ancestors

### DIFF
--- a/src/ProGPU.Wpf.Tests/ProGpuWpfDrawingFrameTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfDrawingFrameTests.cs
@@ -1176,6 +1176,68 @@ public sealed class ProGpuWpfDrawingFrameTests
     }
 
     [Fact]
+    public void BranchMapPromotesSharedBranchToUniqueOwnerAncestor()
+    {
+        var branchMap = new WpfRetainedVisualBranchMap();
+        var ancestorSource = new object();
+        var dirtySource = new object();
+        var cleanSource = new object();
+        var ancestorVisual = new ProGpuRetainedDrawingVisual();
+        var sharedVisual = new ProGpuRetainedDrawingVisual
+        {
+            IsDirty = false
+        };
+        ancestorVisual.AddChild(sharedVisual);
+        branchMap.Register(ancestorSource, ancestorVisual);
+        branchMap.Register(dirtySource, sharedVisual);
+        branchMap.Register(cleanSource, sharedVisual);
+
+        var result = branchMap.InvalidateVisualsForSources(
+            new[] { dirtySource });
+        var target = Assert.Single(
+            branchMap.GetReplayTargetsForSources(new[] { dirtySource }));
+
+        Assert.Equal(1, result.SharedWithCleanSourceVisualCount);
+        Assert.Equal(0, result.ReplayTargetConflictCount);
+        Assert.True(result.CanTargetAllDirtySources);
+        Assert.True(sharedVisual.IsDirty);
+        Assert.Same(ancestorSource, target.Source);
+        Assert.Same(ancestorVisual, target.Visual);
+    }
+
+    [Fact]
+    public void BranchMapDeduplicatesBranchesPromotedToSameAncestor()
+    {
+        var branchMap = new WpfRetainedVisualBranchMap();
+        var ancestorSource = new object();
+        var firstDirtySource = new object();
+        var secondDirtySource = new object();
+        var firstCleanSource = new object();
+        var secondCleanSource = new object();
+        var ancestorVisual = new ProGpuRetainedDrawingVisual();
+        var firstSharedVisual = new ProGpuRetainedDrawingVisual();
+        var secondSharedVisual = new ProGpuRetainedDrawingVisual();
+        ancestorVisual.AddChild(firstSharedVisual);
+        ancestorVisual.AddChild(secondSharedVisual);
+        branchMap.Register(ancestorSource, ancestorVisual);
+        branchMap.Register(firstDirtySource, firstSharedVisual);
+        branchMap.Register(firstCleanSource, firstSharedVisual);
+        branchMap.Register(secondDirtySource, secondSharedVisual);
+        branchMap.Register(secondCleanSource, secondSharedVisual);
+
+        var dirtySources = new[] { firstDirtySource, secondDirtySource };
+        var result = branchMap.InvalidateVisualsForSources(dirtySources);
+        var target = Assert.Single(
+            branchMap.GetReplayTargetsForSources(dirtySources));
+
+        Assert.Equal(2, result.SharedWithCleanSourceVisualCount);
+        Assert.Equal(0, result.ReplayTargetConflictCount);
+        Assert.True(result.CanTargetAllDirtySources);
+        Assert.Same(ancestorSource, target.Source);
+        Assert.Same(ancestorVisual, target.Visual);
+    }
+
+    [Fact]
     public void BranchMapReturnsSourceOwnerReplayTargetForDirtyDependency()
     {
         var branchMap = new WpfRetainedVisualBranchMap();

--- a/src/ProGPU.Wpf/Composition/WpfRetainedVisualBranchMap.cs
+++ b/src/ProGPU.Wpf/Composition/WpfRetainedVisualBranchMap.cs
@@ -225,15 +225,21 @@ public sealed class WpfRetainedVisualBranchMap
                 for (var i = 0; i < visualCount; i++)
                 {
                     var visual = visuals[i];
-                    if (!TryGetReplaySourceForVisual(visual, out var replaySource))
+                    if (!TryResolveReplayTargetForVisual(
+                            visual,
+                            out var replaySource,
+                            out var replayVisual))
                     {
                         _scratchReplayTargets.Clear();
                         return Array.Empty<WpfRetainedVisualBranchReplayTarget>();
                     }
 
-                    if (_scratchVisitedVisuals.Add(visual))
+                    if (_scratchVisitedVisuals.Add(replayVisual))
                     {
-                        _scratchReplayTargets.Add(new WpfRetainedVisualBranchReplayTarget(replaySource, visual));
+                        _scratchReplayTargets.Add(
+                            new WpfRetainedVisualBranchReplayTarget(
+                                replaySource,
+                                replayVisual));
                     }
                 }
             }
@@ -258,29 +264,49 @@ public sealed class WpfRetainedVisualBranchMap
         if (visuals.Count == 1)
         {
             var visual = visuals[0];
-            return TryGetReplaySourceForVisual(visual, out var replaySource)
-                ? CreateSingleReplayTarget(replaySource, visual)
+            return TryResolveReplayTargetForVisual(
+                    visual,
+                    out var replaySource,
+                    out var replayVisual)
+                ? CreateSingleReplayTarget(replaySource, replayVisual)
                 : Array.Empty<WpfRetainedVisualBranchReplayTarget>();
         }
 
         _scratchReplayTargets.Clear();
         _scratchTopLevelReplayTargets.Clear();
-        var visualCount = visuals.Count;
-        for (var i = 0; i < visualCount; i++)
+        _scratchVisitedVisuals.Clear();
+        try
         {
-            var visual = visuals[i];
-            if (!TryGetReplaySourceForVisual(visual, out var replaySource))
+            var visualCount = visuals.Count;
+            for (var i = 0; i < visualCount; i++)
             {
-                _scratchReplayTargets.Clear();
-                return Array.Empty<WpfRetainedVisualBranchReplayTarget>();
+                var visual = visuals[i];
+                if (!TryResolveReplayTargetForVisual(
+                        visual,
+                        out var replaySource,
+                        out var replayVisual))
+                {
+                    _scratchReplayTargets.Clear();
+                    return Array.Empty<WpfRetainedVisualBranchReplayTarget>();
+                }
+
+                if (_scratchVisitedVisuals.Add(replayVisual))
+                {
+                    _scratchReplayTargets.Add(
+                        new WpfRetainedVisualBranchReplayTarget(
+                            replaySource,
+                            replayVisual));
+                }
             }
 
-            _scratchReplayTargets.Add(new WpfRetainedVisualBranchReplayTarget(replaySource, visual));
+            return _scratchReplayTargets.Count <= 1
+                ? ReturnReplayTargets(_scratchReplayTargets)
+                : SelectTopLevelReplayTargets(_scratchReplayTargets);
         }
-
-        return _scratchReplayTargets.Count <= 1
-            ? ReturnReplayTargets(_scratchReplayTargets)
-            : SelectTopLevelReplayTargets(_scratchReplayTargets);
+        finally
+        {
+            _scratchVisitedVisuals.Clear();
+        }
     }
 
     private static bool TryGetSingleSource(
@@ -540,7 +566,11 @@ public sealed class WpfRetainedVisualBranchMap
 
             if (!_sourceOwnersByVisual.TryGetValue(visual, out var sourceOwners))
             {
-                replayTargetConflictCount++;
+                if (!TryResolveReplayTargetForVisual(visual, out _, out _))
+                {
+                    replayTargetConflictCount++;
+                }
+
                 continue;
             }
 
@@ -549,7 +579,10 @@ public sealed class WpfRetainedVisualBranchMap
                 continue;
             }
 
-            replayTargetConflictCount++;
+            if (!TryResolveReplayTargetForVisual(visual, out _, out _))
+            {
+                replayTargetConflictCount++;
+            }
 
             sourceOwners.ClassifyAgainst(
                 source,
@@ -612,7 +645,11 @@ public sealed class WpfRetainedVisualBranchMap
                 var visual = invalidatedVisualEnumerator.Current;
                 if (!_sourceOwnersByVisual.TryGetValue(visual, out var sourceOwners))
                 {
-                    replayTargetConflictCount++;
+                    if (!TryResolveReplayTargetForVisual(visual, out _, out _))
+                    {
+                        replayTargetConflictCount++;
+                    }
+
                     continue;
                 }
 
@@ -621,7 +658,10 @@ public sealed class WpfRetainedVisualBranchMap
                     continue;
                 }
 
-                replayTargetConflictCount++;
+                if (!TryResolveReplayTargetForVisual(visual, out _, out _))
+                {
+                    replayTargetConflictCount++;
+                }
 
                 sourceOwners.ClassifyAgainst(
                     visitedSources,
@@ -738,18 +778,27 @@ public sealed class WpfRetainedVisualBranchMap
         owners.Add(source);
     }
 
-    private bool TryGetReplaySourceForVisual(
+    private bool TryResolveReplayTargetForVisual(
         ProGpuVisual visual,
-        out object replaySource)
+        out object replaySource,
+        out ProGpuVisual replayVisual)
     {
         replaySource = null!;
-        if (!_sourceOwnersByVisual.TryGetValue(visual, out var sourceOwners) ||
-            !sourceOwners.TryGetSingle(out replaySource))
+        replayVisual = null!;
+
+        for (ProGpuVisual? current = visual;
+             current != null;
+             current = current.Parent)
         {
-            return false;
+            if (_sourceOwnersByVisual.TryGetValue(current, out var sourceOwners) &&
+                sourceOwners.TryGetSingle(out replaySource))
+            {
+                replayVisual = current;
+                return true;
+            }
         }
 
-        return true;
+        return false;
     }
 
     private static bool IsCoveredByTargetAncestor(
@@ -1460,7 +1509,6 @@ public readonly struct WpfRetainedVisualBranchInvalidationResult
         DirtySourceCount > 0 &&
         UnmappedSourceCount == 0 &&
         InvalidatedVisualCount > 0 &&
-        SharedWithCleanSourceVisualCount == 0 &&
         ReplayTargetConflictCount == 0;
 }
 


### PR DESCRIPTION
## Summary
- promote a shared retained replay target to its nearest uniquely owned ancestor
- deduplicate multiple promoted targets that resolve to the same ancestor
- keep full replay fallback when no unambiguous ancestor exists
- preserve shared-owner diagnostics while treating only unresolved ownership as a replay conflict

## Motivation
A coarse native branch can be associated with both dirty and clean WPF sources. Previously every such branch forced a full retained-tree replay, even when a uniquely owned ancestor provided a safe subtree boundary.

The nearest uniquely owned ancestor is a valid replay boundary because replaying its WPF source reconstructs the whole retained subtree, including clean siblings. Ambiguous root-level ownership still falls back unchanged.

## Validation
- Release build succeeded
- 3 focused ownership/promotion regressions passed
- complete `ProGpuWpfDrawingFrameTests` class: 62 passed, 0 failed
- private cross-platform validation workload:
  - control: `sharedWithClean=5`, `conflicts=5`, `fallback=True`, no branch replay
  - candidate: `sharedWithClean=5`, `conflicts=0`, `fallback=False`, branch replay active

The workload runs on a software-rendered VM, so frame-time samples remain noisy and are not presented as a percentage speedup claim.