### PR TITLE
Prioritize native input in owner-driven portable loops

### DIFF
--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -294,6 +294,10 @@ public sealed class ProGpuWpfWindowHostTests
         Assert.True(nativeEventPoll > doEventsMethodStart);
         Assert.True(ownerDispatcherDrain > nativeEventPoll);
         Assert.Contains(
+            "if (!_usesExternalNativeLoopPump && PresentedFrameCount == 0)",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
             "if (pumpExternalRenderBeforeEvents)\n        {\n            // Externally pumped popup windows",
             source,
             StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -271,6 +271,18 @@ public sealed class ProGpuWpfWindowHostTests
             "ProGPU.Wpf",
             "ProGpuWpfWindowHost.cs"));
 
+        int doEventsMethodStart = source.IndexOf(
+            "public void DoEvents()",
+            StringComparison.Ordinal);
+        int nativeEventPoll = source.IndexOf(
+            "window.DoEvents();",
+            doEventsMethodStart,
+            StringComparison.Ordinal);
+        int ownerDispatcherDrain = source.IndexOf(
+            "ProcessDispatcherQueueCore();",
+            nativeEventPoll,
+            StringComparison.Ordinal);
+
         Assert.DoesNotContain("_window!.Run();", source, StringComparison.Ordinal);
         Assert.Contains("RunPortableNativeLoop();", source, StringComparison.Ordinal);
         Assert.Contains("private void RunPortableNativeLoop()", source, StringComparison.Ordinal);
@@ -278,6 +290,13 @@ public sealed class ProGpuWpfWindowHostTests
         Assert.Contains("DoEvents();", source, StringComparison.Ordinal);
         Assert.Contains("if (!EnsureCompositionTargetLoaded() || !ShouldKeepPortableNativeRunLoopAlive())", source, StringComparison.Ordinal);
         Assert.Contains("window.DoEvents();\n        }\n        finally\n        {\n            ProcessDeferredNativeWindowDisposals();", source, StringComparison.Ordinal);
+        Assert.True(doEventsMethodStart >= 0);
+        Assert.True(nativeEventPoll > doEventsMethodStart);
+        Assert.True(ownerDispatcherDrain > nativeEventPoll);
+        Assert.Contains(
+            "if (pumpExternalRenderBeforeEvents)\n        {\n            // Externally pumped popup windows",
+            source,
+            StringComparison.Ordinal);
         Assert.Contains("if (ShouldPumpNativeRender())", source, StringComparison.Ordinal);
         Assert.Contains("NativeRenderPumpCount++;\n            window.DoRender();", source, StringComparison.Ordinal);
         Assert.Contains("SkippedNativeRenderPumpCount++;", source, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -1059,6 +1059,19 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             return;
         }
 
+        if (!_usesExternalNativeLoopPump && PresentedFrameCount == 0)
+        {
+            // Complete cold-start dispatcher work before polling a potentially
+            // large native pointer backlog. Once the first frame is visible,
+            // owner-driven windows poll native input first for responsiveness.
+            ProcessDispatcherQueueCore();
+            if (!ShouldKeepPortableNativeRunLoopAlive())
+            {
+                DisposeDeferredNativeWindowIfNeeded();
+                return;
+            }
+        }
+
         bool pumpExternalRenderBeforeEvents = ShouldPumpExternalNativeRenderBeforeEvents(
             _usesExternalNativeLoopPump,
             ShouldPumpNativeRender());

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -1040,7 +1040,6 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     public void DoEvents()
     {
         ThrowIfDisposed();
-        ProcessDispatcherQueueCore();
         EnsureWindow();
         IWindow window = _window!;
         if (!window.IsInitialized)
@@ -1060,10 +1059,22 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             return;
         }
 
-        if (ShouldPumpExternalNativeRenderBeforeEvents(
-                _usesExternalNativeLoopPump,
-                ShouldPumpNativeRender()))
+        bool pumpExternalRenderBeforeEvents = ShouldPumpExternalNativeRenderBeforeEvents(
+            _usesExternalNativeLoopPump,
+            ShouldPumpNativeRender());
+        if (pumpExternalRenderBeforeEvents)
         {
+            // Externally pumped popup windows need their retained hit-test state
+            // current before native input is dispatched. The owner-driven main
+            // loop instead polls native events first so queued dispatcher work
+            // cannot delay clicks, activation, or an interactive window move.
+            ProcessDispatcherQueueCore();
+            if (!ShouldKeepPortableNativeRunLoopAlive())
+            {
+                DisposeDeferredNativeWindowIfNeeded();
+                return;
+            }
+
             NativeRenderPumpCount++;
             window.DoRender();
         }
@@ -1077,6 +1088,13 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             ProcessDeferredNativeWindowDisposals();
         }
 
+        if (!ShouldKeepPortableNativeRunLoopAlive())
+        {
+            DisposeDeferredNativeWindowIfNeeded();
+            return;
+        }
+
+        ProcessDispatcherQueueCore();
         if (!ShouldKeepPortableNativeRunLoopAlive())
         {
             DisposeDeferredNativeWindowIfNeeded();


### PR DESCRIPTION
## Summary
- poll native events before draining queued dispatcher work once the first frame is visible
- preserve the pre-event dispatcher/render pass for externally pumped popup windows
- preserve cold-start ordering so a native pointer backlog cannot starve first presentation
- recheck host liveness after every dispatcher drain before update or render

## Why
Long software-rendered frames can leave clicks, activation, and interactive window moves waiting behind queued dispatcher work. Owner-driven top-level windows can safely poll native events first after initial presentation, while externally pumped popup windows still require current retained hit-test state before input.

## Validation
- Release build succeeded
- 163 `ProGpuWpfWindowHostTests` passed with the Linux ARM64 native WebGPU library on the test path
- VM validation confirmed cold startup presents, native pointer events reach WPF, and the title-drag request reaches the X11 backend
- early and steady-state close paths exited without an unhandled exception