### PR TITLE
Defer rendering for passive pointer motion

### DIFF
--- a/src/ProGPU.Wpf.Tests/WpfPortableWindowActivationTests.cs
+++ b/src/ProGPU.Wpf.Tests/WpfPortableWindowActivationTests.cs
@@ -1327,7 +1327,7 @@ public sealed class WpfPortableWindowActivationTests
     }
 
     [Fact]
-    public void QueuedNativeInputIsProcessedAndRenderedBeforeTheNextEvent()
+    public void QueuedPassivePointerMovesDeferRenderingUntilAfterTheNativeBatch()
     {
         var service = new TestWindowActivationServiceRegistrar
         {
@@ -1352,11 +1352,97 @@ public sealed class WpfPortableWindowActivationTests
                 "BeginInput",
                 "Flush:Input",
                 "ProcessInput:10",
+                "BeginInput",
+                "Flush:Input",
+                "ProcessInput:30"
+            },
+            service.InputDispatchLog);
+    }
+
+    [Fact]
+    public void QueuedPressedPointerMovesRenderBeforeTheNextDragEvent()
+    {
+        var service = new TestWindowActivationServiceRegistrar
+        {
+            QueueInputCallbacks = true,
+            RunQueuedInputOnInputFlush = true
+        };
+        using var serviceRegistration = PortableWpfServiceRegistry.RegisterWindowActivationService(service);
+        using var host = new ProGpuWpfWindowHost();
+        var window = new FakeDispatchingPortableInputWindow();
+        var source = new FakePortablePresentationSource();
+
+        Assert.True(WpfPortableWindowActivation.TryAttach(host, window, source, out var activation));
+        Assert.NotNull(activation);
+
+        RaiseHostInputEvent(host, new WpfInputEventArgs(
+            WpfInputEventKind.MouseDown,
+            x: 10,
+            y: 20,
+            button: WpfMouseButton.Left));
+        RaiseHostInputEvent(host, new WpfInputEventArgs(WpfInputEventKind.MouseMove, x: 20, y: 30));
+        RaiseHostInputEvent(host, new WpfInputEventArgs(
+            WpfInputEventKind.MouseUp,
+            x: 30,
+            y: 40,
+            button: WpfMouseButton.Left));
+        RaiseHostInputEvent(host, new WpfInputEventArgs(WpfInputEventKind.MouseMove, x: 40, y: 50));
+
+        Assert.Equal(4, service.InputCount);
+        Assert.Equal(
+            new[]
+            {
+                "BeginInput",
+                "Flush:Input",
+                "ProcessInput:10",
+                "Flush:Render",
+                "BeginInput",
+                "Flush:Input",
+                "ProcessInput:20",
                 "Flush:Render",
                 "BeginInput",
                 "Flush:Input",
                 "ProcessInput:30",
-                "Flush:Render"
+                "Flush:Render",
+                "BeginInput",
+                "Flush:Input",
+                "ProcessInput:40"
+            },
+            service.InputDispatchLog);
+    }
+
+    [Fact]
+    public void DeactivationClearsPressedPointerRenderFlushing()
+    {
+        var service = new TestWindowActivationServiceRegistrar
+        {
+            QueueInputCallbacks = true,
+            RunQueuedInputOnInputFlush = true
+        };
+        using var serviceRegistration = PortableWpfServiceRegistry.RegisterWindowActivationService(service);
+        using var host = new ProGpuWpfWindowHost();
+        var window = new FakeDispatchingPortableInputWindow();
+        var source = new FakePortablePresentationSource();
+
+        Assert.True(WpfPortableWindowActivation.TryAttach(host, window, source, out var activation));
+        Assert.NotNull(activation);
+
+        RaiseHostInputEvent(host, new WpfInputEventArgs(
+            WpfInputEventKind.MouseDown,
+            x: 10,
+            y: 20,
+            button: WpfMouseButton.Left));
+        RaiseHostWindowEvent(host, WpfWindowEventKind.Deactivated);
+        service.InputDispatchLog.Clear();
+
+        RaiseHostInputEvent(host, new WpfInputEventArgs(WpfInputEventKind.MouseMove, x: 20, y: 30));
+
+        Assert.Equal(
+            new[]
+            {
+                "BeginInput",
+                "Flush:Input",
+                "ProcessInput:20"
             },
             service.InputDispatchLog);
     }

--- a/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
+++ b/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
@@ -59,6 +59,7 @@ public sealed class WpfPortableWindowActivation : IDisposable
     private bool _showActivated = true;
     private bool _isRegisteredNonActivatingOwnedWindow;
     private object? _ownerWindow;
+    private readonly HashSet<WpfMouseButton> _pressedMouseButtons = new();
 
     static WpfPortableWindowActivation()
     {
@@ -518,6 +519,7 @@ public sealed class WpfPortableWindowActivation : IDisposable
         StopDispatcherTimerPump();
         _mediaContextRenderRegistration?.Dispose();
         _mediaContextRenderRegistration = null;
+        _pressedMouseButtons.Clear();
         RemoveNonActivatingOwnedWindowRegistration();
         s_activeActivations.Remove(Window);
         UnregisterActiveActivationHandle(this);
@@ -986,6 +988,7 @@ public sealed class WpfPortableWindowActivation : IDisposable
                 TrySetWindowActivationStateForHostEvent(isActive: true);
                 break;
             case WpfWindowEventKind.Deactivated:
+                _pressedMouseButtons.Clear();
                 DispatchPortableActivationHooks(isActive: false);
                 TrySetWindowActivationStateForHostEvent(isActive: false);
                 break;
@@ -993,6 +996,7 @@ public sealed class WpfPortableWindowActivation : IDisposable
                 DispatchPortableShowWindowHook(isShown: true);
                 break;
             case WpfWindowEventKind.Hidden:
+                _pressedMouseButtons.Clear();
                 DispatchPortableShowWindowHook(isShown: false);
                 break;
             case WpfWindowEventKind.WindowPositionChanging:
@@ -1285,12 +1289,29 @@ public sealed class WpfPortableWindowActivation : IDisposable
             return;
         }
 
-        if (TryDispatchHostInputToWindowDispatcher(e))
+        bool releaseButtonAfterDispatch = e.Kind == WpfInputEventKind.MouseUp &&
+            e.Button != WpfMouseButton.None;
+        if (e.Kind == WpfInputEventKind.MouseDown && e.Button != WpfMouseButton.None)
         {
-            return;
+            _pressedMouseButtons.Add(e.Button);
         }
 
-        ProcessHostInputAndRequestRender(e);
+        try
+        {
+            if (TryDispatchHostInputToWindowDispatcher(e))
+            {
+                return;
+            }
+
+            ProcessHostInputAndRequestRender(e);
+        }
+        finally
+        {
+            if (releaseButtonAfterDispatch)
+            {
+                _pressedMouseButtons.Remove(e.Button);
+            }
+        }
     }
 
     private void ProcessHostInputAndRequestRender(WpfInputEventArgs e)
@@ -1393,11 +1414,19 @@ public sealed class WpfPortableWindowActivation : IDisposable
         if (TryGetWindowActivationService(out var activationService) &&
             activationService.TryBeginInvokeInput(Window, callback))
         {
-            // Silk.NET can report several pointer moves from one native event poll.
-            // Process each queued WPF input callback and its resulting layout before
-            // accepting the next native event.  Controls such as Thumb calculate the
-            // next delta relative to the layout produced by the previous move.
-            FlushWpfDispatcherOperations("Input", "Render");
+            // Passive pointer movement only needs input dispatch here; the owner loop
+            // consumes its render request once after the native event batch. During a
+            // pressed-button interaction, preserve per-event layout because controls
+            // such as Thumb calculate each delta from the preceding move's layout.
+            if (e.Kind == WpfInputEventKind.MouseMove && _pressedMouseButtons.Count == 0)
+            {
+                FlushWpfDispatcherOperations("Input");
+            }
+            else
+            {
+                FlushWpfDispatcherOperations("Input", "Render");
+            }
+
             Host.TryRequestNativeLoopWakeup();
             return true;
         }


### PR DESCRIPTION
## Summary

- flush the input dispatcher only for passive pointer motion so the owner loop can render once after the native batch
- preserve input-plus-render flushing while any pointer button is pressed and for button, wheel, key, and text input
- clear pressed-button tracking on release, deactivation, hide, and disposal

## Why

Native pointer bursts previously forced synchronous rendering after every motion event. This keeps interaction ordering for active gestures while allowing passive motion to coalesce into the normal owner-driven frame.

## Validation

- Release build
- 3 focused pointer-flush behavior tests
- combined host and input regression filter: 169 tests passed
- VM burst: 100 native motion events produced exactly 100 WPF motion events, followed by a clean shutdown