### PR TITLE
Add guarded X11 drag-move fallback

### DIFF
--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19172,7 +19172,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("new X11WindowHandle(x11.Value.Item1, x11.Value.Item2)", source, StringComparison.Ordinal);
         Assert.Contains("TryBeginWin32DragMove(GetWin32Hwnd(view))", source, StringComparison.Ordinal);
         Assert.Contains("TryBeginCocoaDragMove(GetCocoaWindow(view))", source, StringComparison.Ordinal);
-        Assert.Contains("return TryBeginX11DragMove(x11.Display, x11.Window)", source, StringComparison.Ordinal);
+        Assert.Contains("TryBeginX11DragMove(x11Window, x11.Display, x11.Window)", source, StringComparison.Ordinal);
         Assert.Contains("hwnd == IntPtr.Zero", source, StringComparison.Ordinal);
         Assert.Contains("ReleaseCapture();", source, StringComparison.Ordinal);
         Assert.Contains("SendMessage(hwnd, WM_SYSCOMMAND, (IntPtr)SC_MOUSEMOVE, IntPtr.Zero)", source, StringComparison.Ordinal);
@@ -19196,6 +19196,10 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("XSendEvent(", source, StringComparison.Ordinal);
         Assert.Contains("SubstructureRedirectMask | SubstructureNotifyMask", source, StringComparison.Ordinal);
         Assert.Contains("XFlush(display)", source, StringComparison.Ordinal);
+        Assert.Contains("TryContinueX11DragMove(view)", source, StringComparison.Ordinal);
+        Assert.Contains("(buttonMask & Button1Mask) == 0", source, StringComparison.Ordinal);
+        Assert.Contains("!view.Position.Equals(_x11DragExpectedPosition)", source, StringComparison.Ordinal);
+        Assert.Contains("view.Position = nextPosition", source, StringComparison.Ordinal);
         Assert.DoesNotContain(
             "public bool TryBeginDragMove(object window)\n    {\n        return false;\n    }",
             source,

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19196,9 +19196,11 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("XSendEvent(", source, StringComparison.Ordinal);
         Assert.Contains("SubstructureRedirectMask | SubstructureNotifyMask", source, StringComparison.Ordinal);
         Assert.Contains("XFlush(display)", source, StringComparison.Ordinal);
-        Assert.Contains("TryContinueX11DragMove(view)", source, StringComparison.Ordinal);
-        Assert.Contains("(buttonMask & Button1Mask) == 0", source, StringComparison.Ordinal);
-        Assert.Contains("!view.Position.Equals(_x11DragExpectedPosition)", source, StringComparison.Ordinal);
+        Assert.Contains("TryContinueX11DragMove(view, input)", source, StringComparison.Ordinal);
+        Assert.Contains("(buttonMask & Button1Mask) != 0", source, StringComparison.Ordinal);
+        Assert.Contains("input.X - _x11DragStartLocalX", source, StringComparison.Ordinal);
+        Assert.Contains("eventMatchesLivePointer && !_x11FallbackApplied", source, StringComparison.Ordinal);
+        Assert.Contains("!currentPosition.Equals(_x11DragExpectedPosition)", source, StringComparison.Ordinal);
         Assert.Contains("view.Position = nextPosition", source, StringComparison.Ordinal);
         Assert.DoesNotContain(
             "public bool TryBeginDragMove(object window)\n    {\n        return false;\n    }",

--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -338,6 +338,19 @@ public sealed class ProGpuWpfWindowHostTests
     }
 
     [Fact]
+    public void X11DragMoveFallbackPreservesThePointerToWindowOffset()
+    {
+        var position = SilkNetWpfWindowDecorationService.ResolveX11FallbackPosition(
+            new Vector2D<int>(120, 80),
+            pointerStartX: 150,
+            pointerStartY: 100,
+            pointerX: 205,
+            pointerY: 142);
+
+        Assert.Equal(new Vector2D<int>(175, 122), position);
+    }
+
+    [Fact]
     public void SettingPlatformServicesRebuildsDefaultRenderScheduler()
     {
         using var host = new ProGpuWpfWindowHost();

--- a/src/ProGPU.Wpf/Platform/IWpfPlatformServices.cs
+++ b/src/ProGPU.Wpf/Platform/IWpfPlatformServices.cs
@@ -158,6 +158,15 @@ public interface IWpfWindowDecorationService
 {
     bool TryBeginDragMove(object window);
 
+    bool TryContinueDragMove(object window)
+    {
+        return false;
+    }
+
+    void EndDragMove(object window)
+    {
+    }
+
     bool TryActivate(object window)
     {
         return false;

--- a/src/ProGPU.Wpf/Platform/IWpfPlatformServices.cs
+++ b/src/ProGPU.Wpf/Platform/IWpfPlatformServices.cs
@@ -158,7 +158,11 @@ public interface IWpfWindowDecorationService
 {
     bool TryBeginDragMove(object window);
 
-    bool TryContinueDragMove(object window)
+    void TrackDragMoveInput(object window, WpfInputEventArgs input)
+    {
+    }
+
+    bool TryContinueDragMove(object window, WpfInputEventArgs input)
     {
         return false;
     }

--- a/src/ProGPU.Wpf/Platform/SilkNetWpfWindowDecorationService.cs
+++ b/src/ProGPU.Wpf/Platform/SilkNetWpfWindowDecorationService.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Silk.NET.Core.Contexts;
 using Silk.NET.GLFW;
+using Silk.NET.Maths;
 using Silk.NET.Windowing;
 
 namespace System.Windows.Media.ProGPU.Platform;
@@ -17,11 +18,20 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
     private const int ClientMessage = 33;
     private const int NetWmMoveresizeMove = 8;
     private const int NormalApplicationSource = 1;
+    private const uint Button1Mask = 1u << 8;
     private const int PropModeReplace = 0;
     private const nuint XaAtom = 4;
     private const long SubstructureNotifyMask = 1L << 19;
     private const long SubstructureRedirectMask = 1L << 20;
     private const nuint CWOverrideRedirect = 1u << 9;
+
+    private IWindow? _x11DragWindow;
+    private IntPtr _x11DragDisplay;
+    private UIntPtr _x11DragHandle;
+    private int _x11DragStartRootX;
+    private int _x11DragStartRootY;
+    private Vector2D<int> _x11DragStartPosition;
+    private Vector2D<int> _x11DragExpectedPosition;
 
     public bool TryBeginDragMove(object window)
     {
@@ -43,10 +53,31 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
         if (OperatingSystem.IsLinux())
         {
             var x11 = GetX11Window(view);
-            return TryBeginX11DragMove(x11.Display, x11.Window);
+            return view is IWindow x11Window &&
+                TryBeginX11DragMove(x11Window, x11.Display, x11.Window);
         }
 
         return false;
+    }
+
+    public bool TryContinueDragMove(object window)
+    {
+        if (!OperatingSystem.IsLinux() ||
+            window is not IWindow view ||
+            !ReferenceEquals(view, _x11DragWindow))
+        {
+            return false;
+        }
+
+        return TryContinueX11DragMove(view);
+    }
+
+    public void EndDragMove(object window)
+    {
+        if (ReferenceEquals(window, _x11DragWindow))
+        {
+            ClearX11DragMove();
+        }
     }
 
     public bool TryShowWithoutActivation(object window)
@@ -478,7 +509,7 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
     }
 
     [SupportedOSPlatform("linux")]
-    private static bool TryBeginX11DragMove(IntPtr display, UIntPtr window)
+    private bool TryBeginX11DragMove(IWindow view, IntPtr display, UIntPtr window)
     {
         if (display == IntPtr.Zero || window == UIntPtr.Zero)
         {
@@ -507,10 +538,18 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
                 return false;
             }
 
+            _x11DragWindow = view;
+            _x11DragDisplay = display;
+            _x11DragHandle = window;
+            _x11DragStartRootX = rootX;
+            _x11DragStartRootY = rootY;
+            _x11DragStartPosition = view.Position;
+            _x11DragExpectedPosition = _x11DragStartPosition;
+
             var moveresizeAtom = XInternAtom(display, "_NET_WM_MOVERESIZE", onlyIfExists: false);
             if (moveresizeAtom == UIntPtr.Zero)
             {
-                return false;
+                return true;
             }
 
             XUngrabPointer(display, UIntPtr.Zero);
@@ -538,16 +577,103 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
                 ref message) != 0;
 
             XFlush(display);
-            return sent;
+            // XSendEvent only confirms that the request reached the root window. Some
+            // XWayland compositors reject synthetic interactive-move requests. Keep a
+            // pending client-side fallback; it activates only if button-one remains down,
+            // the WM has not moved the window, and motion still reaches this client.
+            return sent || _x11DragWindow != null;
         }
         catch (DllNotFoundException)
         {
+            ClearX11DragMove();
             return false;
         }
         catch (EntryPointNotFoundException)
         {
+            ClearX11DragMove();
             return false;
         }
+    }
+
+    [SupportedOSPlatform("linux")]
+    private bool TryContinueX11DragMove(IWindow view)
+    {
+        try
+        {
+            if (_x11DragDisplay == IntPtr.Zero ||
+                _x11DragHandle == UIntPtr.Zero ||
+                XQueryPointer(
+                    _x11DragDisplay,
+                    XDefaultRootWindow(_x11DragDisplay),
+                    out _,
+                    out _,
+                    out var rootX,
+                    out var rootY,
+                    out _,
+                    out _,
+                    out var buttonMask) == 0 ||
+                (buttonMask & Button1Mask) == 0)
+            {
+                ClearX11DragMove();
+                return false;
+            }
+
+            // A changed position means the window manager accepted _NET_WM_MOVERESIZE.
+            // Stop tracking immediately so the fallback never competes with native motion.
+            if (!view.Position.Equals(_x11DragExpectedPosition))
+            {
+                ClearX11DragMove();
+                return false;
+            }
+
+            var nextPosition = ResolveX11FallbackPosition(
+                _x11DragStartPosition,
+                _x11DragStartRootX,
+                _x11DragStartRootY,
+                rootX,
+                rootY);
+            if (nextPosition.Equals(_x11DragExpectedPosition))
+            {
+                return false;
+            }
+
+            view.Position = nextPosition;
+            _x11DragExpectedPosition = nextPosition;
+            return true;
+        }
+        catch (DllNotFoundException)
+        {
+            ClearX11DragMove();
+            return false;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            ClearX11DragMove();
+            return false;
+        }
+    }
+
+    internal static Vector2D<int> ResolveX11FallbackPosition(
+        Vector2D<int> windowStart,
+        int pointerStartX,
+        int pointerStartY,
+        int pointerX,
+        int pointerY)
+    {
+        return new Vector2D<int>(
+            windowStart.X + pointerX - pointerStartX,
+            windowStart.Y + pointerY - pointerStartY);
+    }
+
+    private void ClearX11DragMove()
+    {
+        _x11DragWindow = null;
+        _x11DragDisplay = IntPtr.Zero;
+        _x11DragHandle = UIntPtr.Zero;
+        _x11DragStartRootX = 0;
+        _x11DragStartRootY = 0;
+        _x11DragStartPosition = default;
+        _x11DragExpectedPosition = default;
     }
 
     [DllImport("user32.dll")]

--- a/src/ProGPU.Wpf/Platform/SilkNetWpfWindowDecorationService.cs
+++ b/src/ProGPU.Wpf/Platform/SilkNetWpfWindowDecorationService.cs
@@ -545,6 +545,8 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
             _x11DragStartRootY = rootY;
             _x11DragStartPosition = view.Position;
             _x11DragExpectedPosition = _x11DragStartPosition;
+            TraceX11DragMove(
+                $"begin pointer=({rootX},{rootY}), window={_x11DragStartPosition}, handle={window}");
 
             var moveresizeAtom = XInternAtom(display, "_NET_WM_MOVERESIZE", onlyIfExists: false);
             if (moveresizeAtom == UIntPtr.Zero)
@@ -601,27 +603,47 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
         try
         {
             if (_x11DragDisplay == IntPtr.Zero ||
-                _x11DragHandle == UIntPtr.Zero ||
+                _x11DragHandle == UIntPtr.Zero)
+            {
+                TraceX11DragMove("cancel: native handle is unavailable");
+                ClearX11DragMove();
+                return false;
+            }
+
+            var root = XDefaultRootWindow(_x11DragDisplay);
+            if (root == UIntPtr.Zero ||
                 XQueryPointer(
                     _x11DragDisplay,
-                    XDefaultRootWindow(_x11DragDisplay),
+                    root,
                     out _,
                     out _,
                     out var rootX,
                     out var rootY,
                     out _,
                     out _,
-                    out var buttonMask) == 0 ||
-                (buttonMask & Button1Mask) == 0)
+                    out var buttonMask) == 0)
             {
+                TraceX11DragMove("cancel: pointer query failed");
+                ClearX11DragMove();
+                return false;
+            }
+
+            var currentPosition = view.Position;
+            TraceX11DragMove(
+                $"continue pointer=({rootX},{rootY}), mask=0x{buttonMask:x}, " +
+                $"window={currentPosition}, expected={_x11DragExpectedPosition}");
+            if ((buttonMask & Button1Mask) == 0)
+            {
+                TraceX11DragMove("cancel: left button is no longer pressed");
                 ClearX11DragMove();
                 return false;
             }
 
             // A changed position means the window manager accepted _NET_WM_MOVERESIZE.
             // Stop tracking immediately so the fallback never competes with native motion.
-            if (!view.Position.Equals(_x11DragExpectedPosition))
+            if (!currentPosition.Equals(_x11DragExpectedPosition))
             {
+                TraceX11DragMove("cancel: native window position already changed");
                 ClearX11DragMove();
                 return false;
             }
@@ -639,6 +661,7 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
 
             view.Position = nextPosition;
             _x11DragExpectedPosition = nextPosition;
+            TraceX11DragMove($"applied position={nextPosition}");
             return true;
         }
         catch (DllNotFoundException)
@@ -674,6 +697,17 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
         _x11DragStartRootY = 0;
         _x11DragStartPosition = default;
         _x11DragExpectedPosition = default;
+    }
+
+    private static void TraceX11DragMove(string message)
+    {
+        if (string.Equals(
+                Environment.GetEnvironmentVariable("PROGPU_WPF_TRACE_NATIVE_LOOP"),
+                "1",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            Console.WriteLine($"ProGPU WPF X11 drag: {message}");
+        }
     }
 
     [DllImport("user32.dll")]

--- a/src/ProGPU.Wpf/Platform/SilkNetWpfWindowDecorationService.cs
+++ b/src/ProGPU.Wpf/Platform/SilkNetWpfWindowDecorationService.cs
@@ -28,8 +28,16 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
     private IWindow? _x11DragWindow;
     private IntPtr _x11DragDisplay;
     private UIntPtr _x11DragHandle;
+    private IWindow? _x11InputWindow;
+    private bool _x11LeftButtonPressed;
+    private bool _x11HasLeftButtonDownPosition;
+    private double _x11LeftButtonDownX;
+    private double _x11LeftButtonDownY;
     private int _x11DragStartRootX;
     private int _x11DragStartRootY;
+    private double _x11DragStartLocalX;
+    private double _x11DragStartLocalY;
+    private bool _x11FallbackApplied;
     private Vector2D<int> _x11DragStartPosition;
     private Vector2D<int> _x11DragExpectedPosition;
 
@@ -60,7 +68,29 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
         return false;
     }
 
-    public bool TryContinueDragMove(object window)
+    public void TrackDragMoveInput(object window, WpfInputEventArgs input)
+    {
+        if (!OperatingSystem.IsLinux() || window is not IWindow view)
+        {
+            return;
+        }
+
+        if (input.Kind == WpfInputEventKind.MouseDown && input.Button == WpfMouseButton.Left)
+        {
+            ClearX11DragMove();
+            _x11InputWindow = view;
+            _x11LeftButtonPressed = true;
+            _x11HasLeftButtonDownPosition = true;
+            _x11LeftButtonDownX = input.X;
+            _x11LeftButtonDownY = input.Y;
+        }
+        else if (input.Kind == WpfInputEventKind.MouseUp && input.Button == WpfMouseButton.Left)
+        {
+            _x11LeftButtonPressed = false;
+        }
+    }
+
+    public bool TryContinueDragMove(object window, WpfInputEventArgs input)
     {
         if (!OperatingSystem.IsLinux() ||
             window is not IWindow view ||
@@ -69,12 +99,13 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
             return false;
         }
 
-        return TryContinueX11DragMove(view);
+        return TryContinueX11DragMove(view, input);
     }
 
     public void EndDragMove(object window)
     {
-        if (ReferenceEquals(window, _x11DragWindow))
+        if (ReferenceEquals(window, _x11DragWindow) ||
+            ReferenceEquals(window, _x11InputWindow))
         {
             ClearX11DragMove();
         }
@@ -524,16 +555,34 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
                 return false;
             }
 
-            if (XQueryPointer(
-                    display,
-                    root,
-                    out _,
-                    out _,
-                    out var rootX,
-                    out var rootY,
-                    out _,
-                    out _,
-                    out _) == 0)
+            int rootX;
+            int rootY;
+            var windowPosition = view.Position;
+            if (ReferenceEquals(view, _x11InputWindow) &&
+                _x11LeftButtonPressed &&
+                _x11HasLeftButtonDownPosition)
+            {
+                rootX = windowPosition.X + (int)Math.Round(_x11LeftButtonDownX);
+                rootY = windowPosition.Y + (int)Math.Round(_x11LeftButtonDownY);
+                _x11DragStartLocalX = _x11LeftButtonDownX;
+                _x11DragStartLocalY = _x11LeftButtonDownY;
+            }
+            else if (XQueryPointer(
+                         display,
+                         root,
+                         out _,
+                         out _,
+                         out rootX,
+                         out rootY,
+                         out var windowX,
+                         out var windowY,
+                         out _) != 0)
+            {
+                _x11DragStartLocalX = windowX;
+                _x11DragStartLocalY = windowY;
+                _x11LeftButtonPressed = true;
+            }
+            else
             {
                 return false;
             }
@@ -543,8 +592,9 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
             _x11DragHandle = window;
             _x11DragStartRootX = rootX;
             _x11DragStartRootY = rootY;
-            _x11DragStartPosition = view.Position;
+            _x11DragStartPosition = windowPosition;
             _x11DragExpectedPosition = _x11DragStartPosition;
+            _x11FallbackApplied = false;
             TraceX11DragMove(
                 $"begin pointer=({rootX},{rootY}), window={_x11DragStartPosition}, handle={window}");
 
@@ -598,7 +648,7 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
     }
 
     [SupportedOSPlatform("linux")]
-    private bool TryContinueX11DragMove(IWindow view)
+    private bool TryContinueX11DragMove(IWindow view, WpfInputEventArgs input)
     {
         try
         {
@@ -610,35 +660,14 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
                 return false;
             }
 
-            var root = XDefaultRootWindow(_x11DragDisplay);
-            if (root == UIntPtr.Zero ||
-                XQueryPointer(
-                    _x11DragDisplay,
-                    root,
-                    out _,
-                    out _,
-                    out var rootX,
-                    out var rootY,
-                    out _,
-                    out _,
-                    out var buttonMask) == 0)
+            if (!_x11LeftButtonPressed)
             {
-                TraceX11DragMove("cancel: pointer query failed");
+                TraceX11DragMove("cancel: no tracked left-button press");
                 ClearX11DragMove();
                 return false;
             }
 
             var currentPosition = view.Position;
-            TraceX11DragMove(
-                $"continue pointer=({rootX},{rootY}), mask=0x{buttonMask:x}, " +
-                $"window={currentPosition}, expected={_x11DragExpectedPosition}");
-            if ((buttonMask & Button1Mask) == 0)
-            {
-                TraceX11DragMove("cancel: left button is no longer pressed");
-                ClearX11DragMove();
-                return false;
-            }
-
             // A changed position means the window manager accepted _NET_WM_MOVERESIZE.
             // Stop tracking immediately so the fallback never competes with native motion.
             if (!currentPosition.Equals(_x11DragExpectedPosition))
@@ -648,12 +677,52 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
                 return false;
             }
 
+            int eventRootX = _x11DragStartRootX +
+                (int)Math.Round(input.X - _x11DragStartLocalX);
+            int eventRootY = _x11DragStartRootY +
+                (int)Math.Round(input.Y - _x11DragStartLocalY);
+            int pointerX = eventRootX;
+            int pointerY = eventRootY;
+            int liveRootX = 0;
+            int liveRootY = 0;
+            uint buttonMask = 0;
+            var root = XDefaultRootWindow(_x11DragDisplay);
+            bool pointerQueried = root != UIntPtr.Zero &&
+                XQueryPointer(
+                    _x11DragDisplay,
+                    root,
+                    out _,
+                    out _,
+                    out liveRootX,
+                    out liveRootY,
+                    out _,
+                    out _,
+                    out buttonMask) != 0;
+            bool liveButtonPressed = pointerQueried && (buttonMask & Button1Mask) != 0;
+            bool eventMatchesLivePointer = pointerQueried &&
+                Math.Abs(eventRootX - liveRootX) <= 1 &&
+                Math.Abs(eventRootY - liveRootY) <= 1;
+            if (liveButtonPressed)
+            {
+                pointerX = liveRootX;
+                pointerY = liveRootY;
+            }
+            else if (eventMatchesLivePointer && !_x11FallbackApplied)
+            {
+                TraceX11DragMove("cancel: released pointer has no queued drag motion");
+                ClearX11DragMove();
+                return false;
+            }
+
+            TraceX11DragMove(
+                $"continue event=({eventRootX},{eventRootY}), live=({liveRootX},{liveRootY}), " +
+                $"mask=0x{buttonMask:x}, window={currentPosition}, expected={_x11DragExpectedPosition}");
             var nextPosition = ResolveX11FallbackPosition(
                 _x11DragStartPosition,
                 _x11DragStartRootX,
                 _x11DragStartRootY,
-                rootX,
-                rootY);
+                pointerX,
+                pointerY);
             if (nextPosition.Equals(_x11DragExpectedPosition))
             {
                 return false;
@@ -661,7 +730,13 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
 
             view.Position = nextPosition;
             _x11DragExpectedPosition = nextPosition;
+            _x11FallbackApplied = true;
             TraceX11DragMove($"applied position={nextPosition}");
+            if (!liveButtonPressed && eventMatchesLivePointer)
+            {
+                ClearX11DragMove();
+            }
+
             return true;
         }
         catch (DllNotFoundException)
@@ -693,8 +768,16 @@ public sealed unsafe class SilkNetWpfWindowDecorationService : IWpfWindowDecorat
         _x11DragWindow = null;
         _x11DragDisplay = IntPtr.Zero;
         _x11DragHandle = UIntPtr.Zero;
+        _x11InputWindow = null;
+        _x11LeftButtonPressed = false;
+        _x11HasLeftButtonDownPosition = false;
+        _x11LeftButtonDownX = 0;
+        _x11LeftButtonDownY = 0;
         _x11DragStartRootX = 0;
         _x11DragStartRootY = 0;
+        _x11DragStartLocalX = 0;
+        _x11DragStartLocalY = 0;
+        _x11FallbackApplied = false;
         _x11DragStartPosition = default;
         _x11DragExpectedPosition = default;
     }

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -2864,6 +2864,11 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private void DetachInputService()
     {
         IWindow? window = _window;
+        if (window != null)
+        {
+            PlatformServices.WindowDecorations.EndDragMove(window);
+        }
+
         bool hadSubscription = _inputSubscription != null;
         if (hadSubscription)
         {
@@ -2910,6 +2915,18 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         finally
         {
             _isForwardingPlatformInput = false;
+        }
+
+        if (_window != null)
+        {
+            if (input.Kind == WpfInputEventKind.MouseMove)
+            {
+                PlatformServices.WindowDecorations.TryContinueDragMove(_window);
+            }
+            else if (input.Kind == WpfInputEventKind.MouseUp && input.Button == WpfMouseButton.Left)
+            {
+                PlatformServices.WindowDecorations.EndDragMove(_window);
+            }
         }
 
         RequestRenderAndWakeNativeLoop();

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -2901,6 +2901,11 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         }
 
         TraceInputEvent("native", e);
+        if (_window != null)
+        {
+            PlatformServices.WindowDecorations.TrackDragMoveInput(_window, e);
+        }
+
         var input = NormalizeInputEventForCurrentRenderSurface(e, sender != null);
         TraceInputEvent("wpf", input);
         _isForwardingPlatformInput = true;
@@ -2921,7 +2926,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         {
             if (input.Kind == WpfInputEventKind.MouseMove)
             {
-                PlatformServices.WindowDecorations.TryContinueDragMove(_window);
+                PlatformServices.WindowDecorations.TryContinueDragMove(_window, e);
             }
             else if (input.Kind == WpfInputEventKind.MouseUp && input.Button == WpfMouseButton.Left)
             {


### PR DESCRIPTION
## Summary

- send the standard `_NET_WM_MOVERESIZE` request first
- preserve native mouse-down coordinates and pressed state before delayed WPF dispatch
- fall back to GLFW positioning only when X11 motion still reaches the client and the window manager has not moved the window
- prefer live pointer coordinates for physical drags while replaying queued event-time coordinates when dispatch is delayed
- cancel fallback tracking on native movement, release, input detachment, or unavailable native state
- add opt-in native-loop decision tracing and focused regression coverage

## Why

`XSendEvent` confirms delivery to the root window but not acceptance by the compositor. Mutter/XWayland can reject synthetic interactive-move requests. Querying current pointer state inside a delayed WPF handler is also insufficient because the pointer may already be at the endpoint with the button released.

The fallback remains subordinate to native behavior: any native position change cancels it immediately, so it does not compete with a window manager that accepts `_NET_WM_MOVERESIZE`. Windows and macOS paths are unchanged.

## Validation

- Release build: 0 errors
- focused X11 offset and source-boundary tests: 2 passed
- complete window-host regression class plus X11 boundary test: 165 passed
- VM drag moved the X11 window by exactly the generated pointer delta `(300,160)`
- subsequent WPF close-button mouse-down/up routed normally and the process exited cleanly with code 0