### PR TITLE
Avoid GeometryGroup children ABI mismatch

### DIFF
--- a/src/ProGPU.Wpf.Tests/Composition/Mil/WpfReplayToProGpuCommandTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/Mil/WpfReplayToProGpuCommandTests.cs
@@ -1071,6 +1071,21 @@ public sealed class WpfReplayToProGpuCommandTests
     }
 
     [Fact]
+    public void GeometryGroupThroughProGpuSinkUsesRuntimeChildrenCollectionAbi()
+    {
+        var geometry = new GeometryGroup();
+        geometry.Children.Add(new RectangleGeometry(new System.Windows.Rect(2, 3, 40, 50)));
+        var nativeContext = new ProGpuDrawingContext();
+        using var sink = new ProGpuCompositionCommandSink(new MediaDrawingContext(nativeContext));
+
+        sink.DrawGeometry(Brushes.Blue, null, geometry);
+
+        var command = Assert.Single(nativeContext.Commands);
+        Assert.Equal(RenderCommandType.DrawPath, command.Type);
+        Assert.NotNull(command.Path);
+    }
+
+    [Fact]
     public void PortablePathThroughProGpuSinkReusesCachedNativePathWhenUnchanged()
     {
         var geometry = CreatePortableRectangleGeometry(new FakeRect(2, 3, 40, 50));

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -15698,6 +15698,8 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("PushNativeGeometryClip(MediaGeometry clipGeometry)", proGpuWpfCommandSink, StringComparison.Ordinal);
         Assert.Contains("TryConvertGeometryToNativePath(clipGeometry, _transformStack.Peek()", proGpuWpfCommandSink, StringComparison.Ordinal);
         Assert.Contains("ConditionalWeakTable<MediaGeometry, NativeGeometryPathCache>", proGpuWpfCommandSink, StringComparison.Ordinal);
+        Assert.Contains("case MediaGeometryGroup:", proGpuWpfCommandSink, StringComparison.Ordinal);
+        Assert.DoesNotContain("geometryGroup.Children", proGpuWpfCommandSink, StringComparison.Ordinal);
         Assert.Contains("TryGetCachedNativeGeometryPath(geometry, transform, out path, out bounds)", proGpuWpfCommandSink, StringComparison.Ordinal);
         Assert.Contains("!transform.IsIdentity || !TryReadNativeGeometryPathKey(geometry, out var key)", proGpuWpfCommandSink, StringComparison.Ordinal);
         Assert.Contains("AddNativePathGeometryKey(pathGeometry, ref hash, ref figureCount, ref segmentCount)", proGpuWpfCommandSink, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf/Composition/ProGpuCompositionCommandSink.cs
+++ b/src/ProGPU.Wpf/Composition/ProGpuCompositionCommandSink.cs
@@ -2037,27 +2037,11 @@ public sealed class ProGpuCompositionCommandSink :
                 figureCount++;
                 segmentCount += 4;
                 return true;
-            case MediaGeometryGroup geometryGroup:
-                AddHash(ref hash, 5);
-                AddHash(ref hash, (int)geometryGroup.FillRule);
-                var children = geometryGroup.Children;
-                AddHash(ref hash, children.Count);
-                for (var i = 0; i < children.Count; i++)
-                {
-                    var child = children[i];
-                    if (child == null)
-                    {
-                        AddHash(ref hash, 0);
-                        continue;
-                    }
-
-                    if (!AddNativeGeometryPathKey(child, ref hash, ref figureCount, ref segmentCount, ref geometryCount, depth + 1))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
+            case MediaGeometryGroup:
+                // The lightweight compile-time shim and real WPF expose different
+                // Children return types. Avoid binding to that getter and use the
+                // existing uncached portable conversion path for geometry groups.
+                return false;
             case MediaCombinedGeometry combinedGeometry:
                 AddHash(ref hash, 6);
                 AddHash(ref hash, (int)combinedGeometry.GeometryCombineMode);


### PR DESCRIPTION
## Summary
- avoid binding ProGPU.Wpf to the lightweight shim's `GeometryGroup.Children` return type
- fall back to the existing portable conversion path for geometry groups
- add a functional geometry-group regression test and a source guard against direct getter access

## Why
The compile-time ProGPU shim returns `List<Geometry>`, while real WPF returns `GeometryCollection`. Calling the getter from a packaged renderer causes `MissingMethodException` in portable apps such as Fork.

## Validation
- `dotnet build src/ProGPU.Wpf.Tests/ProGPU.Wpf.Tests.csproj -c Release`
- 4 focused functional/ABI/no-reflection/source-graph tests passed via VSTest
- full suite reached 1,317 passing tests; 7 unrelated pre-existing source-graph/window-registration assertions failed before the remaining long-running tests were stopped