### PR TITLE
Keep foreign EGL contexts out of WebGPU surface creation

### DIFF
--- a/.github/workflows/progpu-wpf-sdk.yml
+++ b/.github/workflows/progpu-wpf-sdk.yml
@@ -237,3 +237,42 @@ jobs:
 
       - name: Run Wayland-session XWayland native input and popup smoke
         run: ./eng/progpu-wpf-linux-xwayland-smoke.sh
+
+  linux-multi-window-smoke:
+    name: Linux headless multi-window render device smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.PROGPU_WPF_QUALIFIED_COMMIT }}
+          submodules: true
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install headless rendering dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libegl-mesa0 \
+            libegl1 \
+            libgl1 \
+            libgl1-mesa-dri \
+            libgles2 \
+            libglx-mesa0 \
+            libx11-6 \
+            libxcursor1 \
+            libxi6 \
+            libxinerama1 \
+            libxrandr2 \
+            mesa-vulkan-drivers \
+            xauth \
+            xvfb
+
+      - name: Run headless multi-window smoke
+        run: ./eng/progpu-wpf-linux-multi-window-smoke.sh

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ GitHub workflows:
 
 See [docs/progpu-wpf-release.md](docs/progpu-wpf-release.md), the
 [canonical WinForms source integration report](reports/canonical-winforms-source-integration.md),
+[docs/progpu-wpf-multi-window-render-device.md](docs/progpu-wpf-multi-window-render-device.md),
 and the ongoing porting reports in [reports/](reports/).
 
 ## Original Upstream README

--- a/docs/progpu-wpf-multi-window-render-device.md
+++ b/docs/progpu-wpf-multi-window-render-device.md
@@ -1,0 +1,63 @@
+# Multi-window rendering on Linux
+
+Opening a second top-level `Window` on a headless X server with Mesa software rendering aborted
+the process inside wgpu's GLES/EGL backend
+([issue #102](https://github.com/wieslawsoltes/LibreWPF/issues/102)):
+
+```
+thread '<unnamed>' panicked at wgpu-hal/src/gles/egl.rs:300:14:
+called `Result::unwrap()` on an `Err` value: BadAccess
+   12: wgpuInstanceCreateSurface
+thread caused non-unwinding panic. aborting.
+```
+
+An EGL context is thread-affine, and wgpu's GLES backend binds and unbinds one around its work,
+`unwrap()`ing the result. Two things in LibreWPF put a foreign context in the way.
+
+**A GLFW client context left current.** Transparent-framebuffer windows
+(`AllowsTransparency="True"`, and the native popups created for one) ask GLFW for a client API so
+its X11 backend picks a visual with an alpha channel. GLFW makes that context current on the
+creating thread; WebGPU never uses it, but `create_surface` releases whatever context the thread
+holds and Mesa answers `EGL_BAD_ACCESS` because the bound context is GLFW's. `ProGpuWpfWindowHost`
+now drops it on window load, before any surface exists. This is what AvalonDock hit when its
+drop-target overlay appeared during a docking drag.
+
+**A WebGPU instance per window.** Requesting an adapter enumerates every backend, GLES included,
+even where wgpu ends up selecting Vulkan, and `enumerate_adapters` makes the GLES context current -
+colliding with the contexts other live instances hold. Native popup hosts always borrowed their
+owner window's device; top-level windows now do the same through a process-wide render device, so
+one instance serves every window. Set `PROGPU_WPF_DISABLE_RENDER_DEVICE_SHARING=1` to opt out (it
+is off on Windows, which presents through D3D12). Sharing is best-effort: if the owner tears its
+device down first, the next window retires it and creates one itself, and any window still using
+the device can hand it on.
+
+## Still broken: rendering through the GLES/EGL backend
+
+The fixes above make multi-window work where wgpu **selects Vulkan**. Where it selects GLES/EGL to
+render through, a second window still aborts, because that backend rebinds its EGL context around
+every device operation with no coordination between windows. It reproduces whether the windows
+share a device or not, so the LibreWPF host cannot arrange around it - it needs a fix in wgpu or in
+ProGPU's use of it. **On Linux, render through Vulkan.** With lavapipe installed, AvalonDock's
+57-test DevFlow suite goes from 57 failures with the process aborted to 56 passing.
+
+## Selecting a backend
+
+LibreWPF has no knob for this, and neither does the environment: wgpu-native reads its backend mask
+from the `WGPUInstanceExtras` chained onto the instance descriptor and does **not** consult
+`WGPU_BACKEND`. That mask is built in ProGPU's `WgpuContext`, outside this repository.
+
+Adapter selection is not neutral either - with both llvmpipe and lavapipe installed,
+`PowerPreference.HighPerformance` prefers the OpenGL adapter, because lavapipe reports itself as a
+CPU adapter. Hiding one driver is the only way to steer it from outside today: force GL/EGL with
+`VK_DRIVER_FILES=/nonexistent/none.json`, or force Vulkan by installing only a Vulkan ICD. Because
+the choice is neither configurable nor predictable, report the selected backend when diagnosing a
+run - `ProGpuWpfDiagnostics.TryGetWindowHost(window, out var host)` then
+`host.CompositionTarget.Context.AdapterName` and `.AdapterBackendType`.
+
+## Test coverage
+
+`src/ProGPU.Wpf.MultiWindowSmokeHarness` opens three top-level windows with transparent secondaries,
+presents frames on all of them, closes the render device owner and opens another, asserting that
+one device serves them all. `eng/progpu-wpf-linux-multi-window-smoke.sh` runs it under `Xvfb` with
+Mesa software rendering, and the `Linux headless multi-window render device smoke` job in
+`.github/workflows/progpu-wpf-sdk.yml` runs that in CI.

--- a/eng/progpu-wpf-linux-multi-window-smoke.sh
+++ b/eng/progpu-wpf-linux-multi-window-smoke.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Opens several top-level ProGPU WPF windows on a headless X server using Mesa
+# software rendering - the environment reported in LibreWPF issue #102, where the
+# second window aborted the process inside wgpu's GLES/EGL backend. The abort
+# crosses the native boundary and cannot be caught in managed code, so the test is
+# simply that the harness runs to completion.
+#
+# This runs against whatever adapter wgpu selects. Forcing its GLES/EGL backend
+# still cannot keep several windows alive in one process - see
+# docs/progpu-wpf-multi-window-render-device.md.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dotnet="${repo_root}/.dotnet/dotnet"
+if [[ ! -x "${dotnet}" ]]; then
+  dotnet="dotnet"
+fi
+
+if [[ "${dotnet}" == "${repo_root}/.dotnet/dotnet" ]]; then
+  export DOTNET_ROOT="${DOTNET_ROOT:-${repo_root}/.dotnet}"
+fi
+
+export DOTNET_ROLL_FORWARD="${DOTNET_ROLL_FORWARD:-Major}"
+export DOTNET_ROLL_FORWARD_TO_PRERELEASE="${DOTNET_ROLL_FORWARD_TO_PRERELEASE:-1}"
+
+if ! command -v Xvfb >/dev/null 2>&1; then
+  echo "Required Linux multi-window smoke dependency 'Xvfb' is unavailable." >&2
+  exit 1
+fi
+
+harness_project="${repo_root}/src/ProGPU.Wpf.MultiWindowSmokeHarness/ProGPU.Wpf.MultiWindowSmokeHarness.csproj"
+harness_output="${repo_root}/artifacts/progpu-wpf-multi-window-smoke"
+runtime_identifier="${PROGPU_WPF_MULTI_WINDOW_SMOKE_RID:-linux-x64}"
+
+echo "Publishing ProGPU WPF multi-window smoke harness (${runtime_identifier})..."
+rm -rf "${harness_output}"
+# A runtime-identifier publish puts libglfw/libwgpu_native next to the harness.
+# Framework-dependent output leaves them under runtimes/<rid>/native, where Silk's
+# native loader does not find them on this lane.
+"${dotnet}" publish "${harness_project}" \
+  -c "${PROGPU_WPF_MULTI_WINDOW_SMOKE_CONFIGURATION:-Release}" \
+  -r "${runtime_identifier}" \
+  --self-contained false \
+  -o "${harness_output}" \
+  -v:minimal
+
+smoke_log="$(mktemp "${TMPDIR:-/tmp}/librewpf-linux-multi-window.XXXXXX")"
+xvfb_pid=""
+cleanup() {
+  status=$?
+  if [[ -n "${xvfb_pid}" ]] && kill -0 "${xvfb_pid}" 2>/dev/null; then
+    kill "${xvfb_pid}" 2>/dev/null || true
+  fi
+  if ((status != 0)); then
+    echo "LibreWPF Linux multi-window smoke log:" >&2
+    cat "${smoke_log}" >&2 || true
+  fi
+  rm -f "${smoke_log}"
+}
+trap cleanup EXIT
+
+display="${PROGPU_WPF_MULTI_WINDOW_SMOKE_DISPLAY:-:99}"
+Xvfb "${display}" -screen 0 1920x1080x24 +extension RANDR +extension GLX +extension XTEST \
+  >"${smoke_log}" 2>&1 &
+xvfb_pid=$!
+
+for _ in $(seq 1 100); do
+  if [[ -e "/tmp/.X11-unix/X${display#:}" ]]; then
+    break
+  fi
+  if ! kill -0 "${xvfb_pid}" 2>/dev/null; then
+    echo "Xvfb exited before the multi-window smoke display was ready." >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+export DISPLAY="${display}"
+# GLFW probes Wayland before X11 and complains when XDG_RUNTIME_DIR is unset.
+runtime_dir="${XDG_RUNTIME_DIR:-}"
+if [[ -z "${runtime_dir}" ]]; then
+  runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/librewpf-xdg-runtime.XXXXXX")"
+  chmod 700 "${runtime_dir}"
+  export XDG_RUNTIME_DIR="${runtime_dir}"
+fi
+
+# Mesa software rendering, exactly as reported: llvmpipe through the GL/EGL lane.
+export LIBGL_ALWAYS_SOFTWARE="${LIBGL_ALWAYS_SOFTWARE:-1}"
+export GALLIUM_DRIVER="${GALLIUM_DRIVER:-llvmpipe}"
+
+echo "Running ProGPU WPF multi-window smoke on ${display}..."
+set +e
+"${dotnet}" "${harness_output}/ProGPU.Wpf.MultiWindowSmokeHarness.dll" >>"${smoke_log}" 2>&1
+harness_status=$?
+set -e
+
+grep -E "^(ProGPU WPF multi-window smoke|')" "${smoke_log}" || true
+
+if ((harness_status != 0)); then
+  echo "ProGPU WPF multi-window smoke failed with exit code ${harness_status}." >&2
+  exit "${harness_status}"
+fi
+
+echo "ProGPU WPF Linux multi-window smoke succeeded."

--- a/eng/progpu-wpf-verify-docs.sh
+++ b/eng/progpu-wpf-verify-docs.sh
@@ -29,6 +29,8 @@ require_text "eng/progpu-preview-package-audit.sh" '<ProGpuPackageVersion>${prog
 require_text ".github/workflows/progpu-wpf-sdk.yml" "librewpf-ci-packages-"
 require_text ".github/workflows/progpu-wpf-sdk.yml" "if-no-files-found: error"
 require_text ".github/workflows/progpu-wpf-sdk.yml" "./eng/progpu-wpf-linux-xwayland-smoke.sh"
+require_text ".github/workflows/progpu-wpf-sdk.yml" "./eng/progpu-wpf-linux-multi-window-smoke.sh"
+require_text "docs/progpu-wpf-multi-window-render-device.md" "PROGPU_WPF_DISABLE_RENDER_DEVICE_SHARING"
 require_text ".github/workflows/progpu-wpf-release.yml" "NUGET_API_KEY"
 require_text ".github/workflows/progpu-wpf-release.yml" "librewpf-v*"
 require_text ".github/workflows/progpu-wpf-release.yml" "refs/tags/librewpf-v"

--- a/src/ProGPU.Wpf.MultiWindowSmokeHarness/Directory.Build.props
+++ b/src/ProGPU.Wpf.MultiWindowSmokeHarness/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <!-- Shadows the repository's WPF Arcade SDK props, like ProGPU.Wpf.Tests does: this harness
+       builds as an ordinary SDK project so its dependencies are copied next to it. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworkVersion>10.0</TargetFrameworkVersion>
+  </PropertyGroup>
+</Project>

--- a/src/ProGPU.Wpf.MultiWindowSmokeHarness/Directory.Build.targets
+++ b/src/ProGPU.Wpf.MultiWindowSmokeHarness/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/src/ProGPU.Wpf.MultiWindowSmokeHarness/ProGPU.Wpf.MultiWindowSmokeHarness.csproj
+++ b/src/ProGPU.Wpf.MultiWindowSmokeHarness/ProGPU.Wpf.MultiWindowSmokeHarness.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <NoWarn>$(NoWarn);IDE0073</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- ProGPU.Wpf references these but does not carry them: it is packaged against the
+         source-built WPF assemblies, which a consumer supplies. -->
+    <ProjectReference Include="..\..\external\ProGPU\src\WindowsBase\WindowsBase.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\external\ProGPU\src\PresentationCore\PresentationCore.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\ProGPU.Wpf\ProGPU.Wpf.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProGPU.Wpf.MultiWindowSmokeHarness/Program.cs
+++ b/src/ProGPU.Wpf.MultiWindowSmokeHarness/Program.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Windows.Media.ProGPU;
+
+// Multi-window native smoke for the ProGPU WPF window host, covering LibreWPF issue #102:
+// opening a second top-level window on a headless X server aborted the process inside wgpu's
+// GLES/EGL backend. The abort is a non-unwinding Rust panic across the native boundary, so no
+// managed handler can observe it - the test is that this process runs to completion.
+//
+// Every window after the first is transparent, which is the shape that reproduced the report:
+// AvalonDock's drop-target overlay. Transparent windows ask GLFW for a client API, and GLFW
+// leaves that context current on the creating thread. Closing the first window and opening
+// another then covers the second half of the problem, a new WebGPU instance whose adapter
+// enumeration touches the GLES backend that live instances already hold.
+internal static class Program
+{
+    private const string TimeoutEnvironmentVariable = "PROGPU_WPF_MULTI_WINDOW_SMOKE_TIMEOUT_SECONDS";
+    private const string DisableSharingEnvironmentVariable = "PROGPU_WPF_DISABLE_RENDER_DEVICE_SHARING";
+    private const int WindowCount = 3;
+    private const int RequiredFrames = 3;
+
+    private static int Main()
+    {
+        int timeoutSeconds = ReadTimeoutSeconds();
+        Console.WriteLine(
+            $"ProGPU WPF multi-window smoke starting: windows={WindowCount}, " +
+            $"timeoutSeconds={timeoutSeconds}, renderDeviceSharing={!IsRenderDeviceSharingDisabled()}");
+
+        var hosts = new List<ProGpuWpfWindowHost>(WindowCount);
+        try
+        {
+            for (int index = 0; index < WindowCount; index++)
+            {
+                // Show and pump each window before creating the next one: a live, presenting
+                // window and then another top-level surface is the reported sequence.
+                ShowWindow(hosts, $"smoke {index + 1}", transparent: index > 0, timeoutSeconds);
+            }
+
+            AssertExactlyOneRenderDeviceOwner(hosts);
+
+            // The windows still open keep the render device alive, so a window opened after the
+            // owner closes must borrow the surviving device rather than build its own.
+            ProGpuWpfWindowHost firstHost = hosts[0];
+            hosts.RemoveAt(0);
+            firstHost.Close();
+            firstHost.Dispose();
+            ProGpuWpfWindowHost reopenedHost =
+                ShowWindow(hosts, "smoke reopened", transparent: true, timeoutSeconds);
+            if (!IsRenderDeviceSharingDisabled() && !reopenedHost.UsesSharedRenderDevice)
+            {
+                throw new InvalidOperationException(
+                    "Expected the window opened after the render device owner closed to borrow " +
+                    "the surviving device.");
+            }
+
+            Console.WriteLine("ProGPU WPF multi-window smoke succeeded.");
+            Console.Out.Flush();
+            return 0;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(exception);
+            Console.Error.Flush();
+            return 1;
+        }
+        finally
+        {
+            for (int index = hosts.Count - 1; index >= 0; index--)
+            {
+                try
+                {
+                    hosts[index].Dispose();
+                }
+                catch (Exception disposeException)
+                {
+                    Console.Error.WriteLine($"Window {index + 1} disposal failed: {disposeException}");
+                }
+            }
+        }
+    }
+
+    private static ProGpuWpfWindowHost ShowWindow(
+        List<ProGpuWpfWindowHost> hosts,
+        string title,
+        bool transparent,
+        int timeoutSeconds)
+    {
+        var host = new ProGpuWpfWindowHost(new ProGpuWpfWindowOptions
+        {
+            Title = $"ProGPU WPF multi-window {title}",
+            Width = 320,
+            Height = 240,
+            Left = 40 + (hosts.Count * 48),
+            Top = 40 + (hosts.Count * 48),
+            IsEventDriven = false,
+            TransparentFramebuffer = transparent
+        });
+        hosts.Add(host);
+        host.Show();
+        PumpUntilPresented(hosts, timeoutSeconds);
+
+        Console.WriteLine(
+            $"'{title}' presented {host.PresentedFrameCount} frame(s): " +
+            $"shared={host.UsesSharedRenderDevice}, adapter='{DescribeAdapter(host)}'");
+        return host;
+    }
+
+    private static void AssertExactlyOneRenderDeviceOwner(List<ProGpuWpfWindowHost> hosts)
+    {
+        if (IsRenderDeviceSharingDisabled())
+        {
+            return;
+        }
+
+        // Exactly one window owns the process render device; every other one borrows it.
+        int ownerCount = 0;
+        for (int index = 0; index < hosts.Count; index++)
+        {
+            if (!hosts[index].UsesSharedRenderDevice)
+            {
+                ownerCount++;
+            }
+        }
+
+        if (ownerCount != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one of {hosts.Count} windows to own the process WebGPU render " +
+                $"device, but {ownerCount} created their own.");
+        }
+    }
+
+    private static void PumpUntilPresented(List<ProGpuWpfWindowHost> hosts, int timeoutSeconds)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(timeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            bool presented = true;
+            for (int index = 0; index < hosts.Count; index++)
+            {
+                // Nothing here invalidates a visual tree, so ask for each frame explicitly.
+                // Presenting repeatedly exercises every window's swap chain rather than only
+                // its first surface configuration.
+                ProGpuWpfDiagnostics.TryRequestRender(hosts[index]);
+                hosts[index].DoEvents();
+                presented &= hosts[index].PresentedFrameCount >= RequiredFrames;
+            }
+
+            if (presented)
+            {
+                return;
+            }
+
+            Thread.Sleep(8);
+        }
+
+        throw new TimeoutException(
+            $"Expected {hosts.Count} window(s) to present {RequiredFrames} frame(s) within " +
+            $"{timeoutSeconds} seconds.");
+    }
+
+    private static string DescribeAdapter(ProGpuWpfWindowHost host)
+    {
+        // The selected backend is neither configurable nor predictable, so report it: a run that
+        // behaves differently from another usually picked a different one.
+        var context = host.CompositionTarget?.Context;
+        return context == null
+            ? "unavailable"
+            : $"{context.AdapterName} ({context.AdapterBackendType})";
+    }
+
+    private static bool IsRenderDeviceSharingDisabled()
+    {
+        return string.Equals(
+            Environment.GetEnvironmentVariable(DisableSharingEnvironmentVariable),
+            "1",
+            StringComparison.Ordinal);
+    }
+
+    private static int ReadTimeoutSeconds()
+    {
+        string? value = Environment.GetEnvironmentVariable(TimeoutEnvironmentVariable);
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) && parsed > 0
+            ? parsed
+            : 120;
+    }
+}

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -12598,11 +12598,11 @@ public sealed class WpfManagedProjectGraphTests
 
         Assert.Contains("name: LibreWPF Build", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.Contains("PROGPU_WPF_QUALIFIED_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}", sdkCiWorkflow, StringComparison.Ordinal);
-        Assert.Equal(6, sdkCiWorkflow.Split("ref: ${{ env.PROGPU_WPF_QUALIFIED_COMMIT }}", StringSplitOptions.None).Length - 1);
-        Assert.Equal(15, sdkCiWorkflow.Split("${{ env.PROGPU_WPF_QUALIFIED_COMMIT }}", StringSplitOptions.None).Length - 1);
+        Assert.Equal(7, sdkCiWorkflow.Split("ref: ${{ env.PROGPU_WPF_QUALIFIED_COMMIT }}", StringSplitOptions.None).Length - 1);
+        Assert.Equal(16, sdkCiWorkflow.Split("${{ env.PROGPU_WPF_QUALIFIED_COMMIT }}", StringSplitOptions.None).Length - 1);
         Assert.DoesNotContain("librewpf-ci-packages-${{ github.sha }}", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.DoesNotContain("librewpf-windows-managed-runtime-${{ github.sha }}", sdkCiWorkflow, StringComparison.Ordinal);
-        Assert.Equal(2, sdkCiWorkflow.Split("submodules: true", StringSplitOptions.None).Length - 1);
+        Assert.Equal(3, sdkCiWorkflow.Split("submodules: true", StringSplitOptions.None).Length - 1);
         Assert.Contains("submodules: recursive", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.Contains("./eng/progpu-wpf-canonical-winforms-integration.sh", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.Contains("Download canonical LibreWinForms package closure", sdkCiWorkflow, StringComparison.Ordinal);
@@ -12612,6 +12612,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.DoesNotContain("Stage exact ProGPU release packages", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.Contains("global-json-file: global.json", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.Contains("./eng/progpu-wpf-sdk-ci.sh", sdkCiWorkflow, StringComparison.Ordinal);
+        Assert.Contains("./eng/progpu-wpf-linux-multi-window-smoke.sh", sdkCiWorkflow, StringComparison.Ordinal);
         Assert.Contains("name: LibreWPF Docs", docsWorkflow, StringComparison.Ordinal);
         Assert.Contains("submodules: true", docsWorkflow, StringComparison.Ordinal);
         Assert.DoesNotContain("submodules: recursive", docsWorkflow, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/ProGpuWpfRenderDeviceSharingTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfRenderDeviceSharingTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Windows.Media.ProGPU;
+using Xunit;
+
+namespace ProGPU.Wpf.Tests;
+
+[Collection(PortableRenderDataSinkProviderCollection.Name)]
+public sealed class ProGpuWpfRenderDeviceSharingTests
+{
+    [Theory]
+    // Windows presents through D3D12, where a per-window device is the shipped configuration.
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    public void RenderDeviceSharingFollowsThePlatformAndTheOptOut(
+        bool isWindows,
+        bool explicitlyDisabled,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ProGpuWpfRenderDeviceSharing.ShouldShareRenderDevice(isWindows, explicitlyDisabled));
+    }
+
+    [Fact]
+    public void RegisteringADeviceOwnerRequiresAContext()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => ProGpuWpfRenderDeviceSharing.RegisterDeviceOwnerContext(null!));
+    }
+
+    [Fact]
+    public void RetiringAnAbsentDeviceOwnerIsANoOp()
+    {
+        ProGpuWpfRenderDeviceSharing.RetireDeviceOwnerContext(null);
+    }
+
+    [Fact]
+    public void WindowHostsWithoutACompositionTargetReportNoSharedRenderDevice()
+    {
+        using var host = new ProGpuWpfWindowHost();
+
+        Assert.False(host.UsesSharedRenderDevice);
+    }
+}

--- a/src/ProGPU.Wpf/ProGpuWpfRenderDeviceSharing.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfRenderDeviceSharing.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using ProGPU.Backend;
+
+namespace System.Windows.Media.ProGPU;
+
+/// <summary>
+/// Tracks the process-wide WebGPU render device - instance, adapter, device and queue - that
+/// top-level window hosts borrow instead of each creating their own.
+/// </summary>
+/// <remarks>
+/// Requesting an adapter enumerates every wgpu backend, GLES included, even where wgpu ends up
+/// selecting another one. Enumerating the GLES backend makes its EGL context current, which
+/// collides with the contexts other live instances hold and aborts the process from native code.
+/// Keeping one instance for the process avoids that, and also stops every window from
+/// duplicating an adapter, device, queue and device resource domain.
+/// </remarks>
+internal static class ProGpuWpfRenderDeviceSharing
+{
+    private static readonly object s_sync = new();
+    private static readonly List<WgpuContext> s_deviceOwners = new();
+    private static bool s_isContextDisposingHooked;
+
+    internal static bool IsEnabled => ShouldShareRenderDevice(
+        OperatingSystem.IsWindows(),
+        string.Equals(
+            Environment.GetEnvironmentVariable("PROGPU_WPF_DISABLE_RENDER_DEVICE_SHARING"),
+            "1",
+            StringComparison.Ordinal));
+
+    internal static bool ShouldShareRenderDevice(bool isWindows, bool explicitlyDisabled)
+    {
+        // Windows presents through the D3D12 backend, where a per-window device is the shipped
+        // and most exercised configuration. Every other platform can reach wgpu's GLES backend.
+        return !isWindows && !explicitlyDisabled;
+    }
+
+    /// <summary>
+    /// Returns a live context whose render device a new window can borrow, or <c>null</c> when
+    /// the next window has to create the process render device itself.
+    /// </summary>
+    internal static WgpuContext? TryGetDeviceOwnerContext()
+    {
+        lock (s_sync)
+        {
+            PruneRetiredContexts();
+            return s_deviceOwners.Count == 0 ? null : s_deviceOwners[0];
+        }
+    }
+
+    /// <summary>
+    /// Publishes a window context as a render device owner for later windows. The context that
+    /// created the device and the contexts that borrowed it can all hand the same device on, so
+    /// closing the first window does not force the next one onto a private device.
+    /// </summary>
+    internal static void RegisterDeviceOwnerContext(WgpuContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        lock (s_sync)
+        {
+            if (!s_isContextDisposingHooked)
+            {
+                WgpuContext.Disposing += RetireDeviceOwnerContext;
+                s_isContextDisposingHooked = true;
+            }
+
+            PruneRetiredContexts();
+            if (!s_deviceOwners.Contains(context))
+            {
+                s_deviceOwners.Add(context);
+            }
+        }
+    }
+
+    /// <summary>Drops a context that can no longer hand out its render device.</summary>
+    internal static void RetireDeviceOwnerContext(WgpuContext? context)
+    {
+        if (context == null)
+        {
+            return;
+        }
+
+        lock (s_sync)
+        {
+            s_deviceOwners.Remove(context);
+        }
+    }
+
+    private static void PruneRetiredContexts()
+    {
+        // Disposing fires before IsDisposed flips, so both are needed to keep the list live.
+        for (int i = s_deviceOwners.Count - 1; i >= 0; i--)
+        {
+            if (s_deviceOwners[i].IsDisposed)
+            {
+                s_deviceOwners.RemoveAt(i);
+            }
+        }
+    }
+}

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -74,6 +74,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private bool _isNativeLoopRunning;
     private bool _usesExternalNativeLoopPump;
     private bool _isLoadingCompositionTarget;
+    private bool _usesSharedRenderDevice;
     private bool _disposeNativeWindowWhenLoopExits;
     private bool _hasPresentedFrame;
     private long _presentedFrameCount;
@@ -166,6 +167,12 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     public IWindow? SilkWindow => _window;
 
     public ProGpuWpfCompositionTarget? CompositionTarget => _target;
+
+    /// <summary>
+    /// Gets a value indicating whether this window renders through a WebGPU device that it
+    /// borrowed from another window instead of a device it created itself.
+    /// </summary>
+    public bool UsesSharedRenderDevice => _target != null && _usesSharedRenderDevice;
 
     public ProGpuDirectXDevice? DirectXDevice
     {
@@ -1426,7 +1433,26 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         AttachNativeDpiService();
         _windowController?.Attach();
         ApplyWindowIcon();
+        ReleaseUnusedClientGraphicsContext();
         EnsureCompositionTargetLoaded();
+    }
+
+    private void ReleaseUnusedClientGraphicsContext()
+    {
+        // Transparent-framebuffer windows ask GLFW for a client API so its X11 backend picks a
+        // visual with an alpha channel, and GLFW makes that context current on this thread.
+        // WebGPU owns presentation and never uses it, but wgpu's GLES backend releases the
+        // thread's current context while creating a surface - eglMakeCurrent(display, NULL,
+        // NULL, NULL) - and Mesa answers EGL_BAD_ACCESS when that context is GLFW's rather than
+        // wgpu's, aborting the process from native code.
+        try
+        {
+            _window?.GLContext?.Clear();
+        }
+        catch (Exception exception)
+        {
+            TraceNativeLoop("client graphics context release failed: " + exception);
+        }
     }
 
     private bool EnsureCompositionTargetLoaded()
@@ -1461,10 +1487,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         try
         {
             IWindow window = _window;
-            ProGpuWpfCompositionTarget target = ProGpuWpfCompositionTarget.CreateForWindow(
-                window,
-                _options.SharedRenderDeviceContext,
-                _options.CompositorOptions);
+            ProGpuWpfCompositionTarget target = CreateCompositionTargetForWindow(window);
             if (_options.TransparentFramebuffer)
             {
                 target.Compositor.ClearColor = System.Numerics.Vector4.Zero;
@@ -1518,6 +1541,48 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         {
             _isLoadingCompositionTarget = false;
         }
+    }
+
+    private ProGpuWpfCompositionTarget CreateCompositionTargetForWindow(IWindow window)
+    {
+        // Native popup hosts name their owner window's context explicitly; top-level windows
+        // borrow the process render device instead.
+        bool usesProcessRenderDevice =
+            _options.SharedRenderDeviceContext == null &&
+            ProGpuWpfRenderDeviceSharing.IsEnabled;
+        WgpuContext? deviceOwner = usesProcessRenderDevice
+            ? ProGpuWpfRenderDeviceSharing.TryGetDeviceOwnerContext()
+            : _options.SharedRenderDeviceContext;
+
+        ProGpuWpfCompositionTarget? target = null;
+        if (deviceOwner != null)
+        {
+            try
+            {
+                target = ProGpuWpfCompositionTarget.CreateForWindow(
+                    window,
+                    deviceOwner,
+                    _options.CompositorOptions);
+            }
+            catch (InvalidOperationException) when (usesProcessRenderDevice)
+            {
+                // The owner tore its device down between selection and surface creation, so
+                // retire it and let this window create the process render device instead.
+                ProGpuWpfRenderDeviceSharing.RetireDeviceOwnerContext(deviceOwner);
+            }
+        }
+
+        _usesSharedRenderDevice = target != null;
+        target ??= ProGpuWpfCompositionTarget.CreateForWindow(
+            window,
+            sharedDeviceContext: null,
+            _options.CompositorOptions);
+        if (usesProcessRenderDevice)
+        {
+            ProGpuWpfRenderDeviceSharing.RegisterDeviceOwnerContext(target.Context);
+        }
+
+        return target;
     }
 
     private bool CanFinishCompositionTargetLoad(ProGpuWpfCompositionTarget target, IWindow window)
@@ -3389,9 +3454,11 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
 
         ProGpuWpfCompositionTarget target = _target;
         _target = null;
+        _usesSharedRenderDevice = false;
         _directXDevice?.Dispose();
         _directXDevice = null;
         target.RenderInvalidated -= OnCompositionTargetRenderInvalidated;
+        ProGpuWpfRenderDeviceSharing.RetireDeviceOwnerContext(target.Context);
         target.Dispose();
         WpfRenderScheduler.Reset();
         Volatile.Write(ref _pendingRenderRequestIsWakeOnly, 0);


### PR DESCRIPTION
Opening a second top-level window on a headless X server aborted the process inside wgpu's GLES/EGL backend (issue #102). An EGL context is thread-affine, and that backend binds and unbinds one around its work, unwrap()ing the result; two things in LibreWPF put a foreign context in the way.

Transparent-framebuffer windows ask GLFW for a client API so its X11 backend picks a visual with an alpha channel, and GLFW makes that context current on the creating thread. WebGPU never uses it, but create_surface releases whatever context the thread holds and Mesa answers EGL_BAD_ACCESS because the bound context is GLFW's. Drop it on window load, before any surface exists. This is the abort AvalonDock hit when its drop-target overlay - a transparent top-level window - appeared during a docking drag.

Requesting an adapter then enumerates every backend, GLES included, even where wgpu ends up selecting Vulkan, and enumerate_adapters makes the GLES context current, colliding with the contexts other live instances hold. Native popup hosts always borrowed their owner window's device; top-level windows now do the same through a process-wide render device, so one instance serves every window. PROGPU_WPF_DISABLE_RENDER_DEVICE_SHARING=1 opts out, and it is off on Windows, which presents through D3D12.

Verified against the reporter's suite: AvalonDock's 57-test DevFlow docking tests (Dirkster99/AvalonDock#646) under Xvfb with Mesa software rendering go from 57 failures with the process aborted to 56 passing, the one remaining failure a drag-position assertion that reproduces identically without these changes. ProGPU.Wpf.MultiWindowSmokeHarness reproduces the abort directly and eng/progpu-wpf-linux-multi-window-smoke.sh runs it in CI.

Selecting wgpu's GLES/EGL backend to render through is still broken for several windows: it rebinds its EGL context around every device operation with no coordination between windows, and aborts whether the windows share a device or not. That needs a fix in wgpu or in ProGPU's use of it; Linux has to render through Vulkan until then.
