### PR TITLE
[WIP] Guard GetWindowLongPtr/GetWindowLong behind OperatingSystem.IsWindows() to fix macOS crash

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsOther.cs
@@ -401,6 +401,15 @@ namespace MS.Win32
 
         internal static IntPtr GetWindowLongPtr(HandleRef hWnd, int nIndex)
         {
+            // Window longs are a Win32-only concept, and the imports below resolve against
+            // PresentationNative_cor3.dll, which does not exist off Windows - calling them there
+            // faults the process with a DllNotFoundException rather than failing gracefully.
+            // Portable windows carry no Win32 window styles, so report "no styles" instead.
+            if (!System.OperatingSystem.IsWindows())
+            {
+                return IntPtr.Zero;
+            }
+
             IntPtr result = IntPtr.Zero;
             int error = 0;
 
@@ -433,6 +442,14 @@ namespace MS.Win32
 
         internal static int GetWindowLong(HandleRef hWnd, int nIndex)
         {
+            // See GetWindowLongPtr: no Win32 window styles exist off Windows, and the underlying
+            // import is unresolvable there. GetWindowStyle() funnels through here, which is how a
+            // hit-test-driven ScreenToClient() used to crash the process on macOS.
+            if (!System.OperatingSystem.IsWindows())
+            {
+                return 0;
+            }
+
             int iResult = 0;
             IntPtr result = IntPtr.Zero;
             int error = 0;

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -22,6 +22,28 @@ public sealed class WpfManagedProjectGraphTests
     }
 
     [Fact]
+    public void UnsafeNativeMethodsWindowLongsFailSoftOffWindows()
+    {
+        var unsafeNativeMethods = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "Shared",
+            "MS",
+            "Win32",
+            "UnsafeNativeMethodsOther.cs"));
+
+        // Window longs resolve against PresentationNative_cor3.dll, which does not exist
+        // off-Windows. The managed entry points must report "no styles" there instead of
+        // faulting the process with DllNotFoundException (GetWindowStyle funnels through
+        // GetWindowLong, so a hit-test-driven ScreenToClient used to crash macOS).
+        var noStylesPtr = "if (!System.OperatingSystem.IsWindows())\n            {\n                return IntPtr.Zero;\n            }";
+        var noStylesInt = "if (!System.OperatingSystem.IsWindows())\n            {\n                return 0;\n            }";
+        AssertGuardBefore(unsafeNativeMethods, noStylesPtr, "NativeMethodsSetLastError.GetWindowLongPtr(hWnd, nIndex)");
+        AssertGuardBefore(unsafeNativeMethods, noStylesInt, "iResult = NativeMethodsSetLastError.GetWindowLong(hWnd, nIndex);");
+    }
+
+    [Fact]
     public void FocusedProGpuWpfGraphAvoidsSharedOutputParallelContention()
     {
         var project = XDocument.Load(FindRepoPath(


### PR DESCRIPTION
## Summary

`MS.Win32.UnsafeNativeMethods.GetWindowLongPtr` / `GetWindowLong` resolve against `PresentationNative_cor3.dll`, which does not exist off-Windows. Any code path that reaches them on macOS (e.g. hit-test-driven `ScreenToClient()` funneling through `GetWindowStyle()`) faults the process with an unhandled `DllNotFoundException` instead of failing gracefully.

Portable windows carry no Win32 window styles, so this adds an early `OperatingSystem.IsWindows()` guard returning the "no styles" defaults (`IntPtr.Zero` / `0`) — mirroring how other Win32-only surface in this repo is already guarded.

## Reproduction (before)

Reflection probe over a package-mode app on macOS arm64:

```
CRASH: MS.Win32.UnsafeNativeMethods.GetWindowLongPtr -> DllNotFoundException:
       Unable to load shared library 'PresentationNative_cor3.dll'
CRASH: MS.Win32.UnsafeNativeMethods.GetWindowLong -> DllNotFoundException
```

## Verification (after)

Same probe against a transport rebuilt with this change:

```
OK: MS.Win32.UnsafeNativeMethods.GetWindowLongPtr -> 0
OK: MS.Win32.UnsafeNativeMethods.GetWindowLong -> 0
```

- Managed transport build clean on macOS arm64 (`BuildManagedTransport`, 0 errors).
- Note: direct calls into `MS.Internal.*.NativeMethodsSetLastError.GetWindowLong*` (WindowsBase/UIAutomationTypes internals) remain unguarded; all real WPF call paths go through the `UnsafeNativeMethods` wrappers covered here. Happy to extend the guard to those classes too if preferred.

Marked draft pending feedback on whether the guard belongs here or in a shared portable-interop seam.
