### PR TITLE
[WIP] Guard against cross-host native event dispatch reentrancy (Silk.NET Reset crash)

### DIFF
--- a/src/ProGPU.Wpf.Tests/Platform/SilkNetWpfInputServiceTests.cs
+++ b/src/ProGPU.Wpf.Tests/Platform/SilkNetWpfInputServiceTests.cs
@@ -291,7 +291,7 @@ public sealed class SilkNetWpfInputServiceTests
     }
 
     [Fact]
-    public void AttachSuppressesMouseUpWithoutMatchingMouseDown()
+    public void AttachForwardsMouseUpWithoutMatchingMouseDown()
     {
         var mouse = new FakeMouse { Position = new Vector2(12, 34) };
         var context = new FakeInputContext();
@@ -310,13 +310,18 @@ public sealed class SilkNetWpfInputServiceTests
             received,
             first =>
             {
-                Assert.Equal(WpfInputEventKind.MouseDown, first.Kind);
+                Assert.Equal(WpfInputEventKind.MouseUp, first.Kind);
                 Assert.Equal(WpfMouseButton.Left, first.Button);
             },
             second =>
             {
-                Assert.Equal(WpfInputEventKind.MouseUp, second.Kind);
+                Assert.Equal(WpfInputEventKind.MouseDown, second.Kind);
                 Assert.Equal(WpfMouseButton.Left, second.Button);
+            },
+            third =>
+            {
+                Assert.Equal(WpfInputEventKind.MouseUp, third.Kind);
+                Assert.Equal(WpfMouseButton.Left, third.Button);
             });
     }
 

--- a/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
+++ b/src/ProGPU.Wpf.Tests/ProGpuWpfWindowHostTests.cs
@@ -290,6 +290,8 @@ public sealed class ProGpuWpfWindowHostTests
         Assert.Contains("DoEvents();", source, StringComparison.Ordinal);
         Assert.Contains("if (!EnsureCompositionTargetLoaded() || !ShouldKeepPortableNativeRunLoopAlive())", source, StringComparison.Ordinal);
         Assert.Contains("window.DoEvents();\n        }\n        finally\n        {\n            ProcessDeferredNativeWindowDisposals();", source, StringComparison.Ordinal);
+        Assert.Contains("Interlocked.Increment(ref s_activeNativeEventDispatchDepth);", source, StringComparison.Ordinal);
+        Assert.Contains("window.DoEvents();\n            if (!ShouldKeepPortableNativeRunLoopAlive())", source, StringComparison.Ordinal);
         Assert.True(doEventsMethodStart >= 0);
         Assert.True(nativeEventPoll > doEventsMethodStart);
         Assert.True(ownerDispatcherDrain > nativeEventPoll);
@@ -302,7 +304,7 @@ public sealed class ProGpuWpfWindowHostTests
             source,
             StringComparison.Ordinal);
         Assert.Contains("if (ShouldPumpNativeRender())", source, StringComparison.Ordinal);
-        Assert.Contains("NativeRenderPumpCount++;\n            window.DoRender();", source, StringComparison.Ordinal);
+        Assert.Contains("NativeRenderPumpCount++;\n                window.DoRender();", source, StringComparison.Ordinal);
         Assert.Contains("SkippedNativeRenderPumpCount++;", source, StringComparison.Ordinal);
         Assert.Contains("Thread.Sleep(hadPendingRender || WpfRenderScheduler.HasPendingRenderRequest", source, StringComparison.Ordinal);
         Assert.Contains("private bool ShouldKeepPortableNativeRunLoopAlive()", source, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -70,6 +70,15 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
     private int _portablePresentationSourceClientOriginX;
     private int _portablePresentationSourceClientOriginY;
     private bool _hasPortablePresentationSourceClientOrigin;
+    // GLFW's event poll is process-global: whichever host instance happens to call
+    // window.DoEvents() dispatches pending native callbacks for every native window, not just its
+    // own (e.g. a mouse-up on a modal dialog can be delivered while the *main* window's host is the
+    // one pumping). A callback can synchronously Close()/Dispose() a *different* host than the one
+    // currently inside window.DoEvents()/DoUpdate()/DoRender(), so the existing _isNativeLoopRunning/
+    // _isRendering/etc. instance flags below don't see it and Dispose() would call Silk.NET's
+    // Reset() reentrantly - which Silk.NET explicitly forbids while any window's render loop is
+    // active, crashing the process. This process-wide counter closes that gap.
+    private static int s_activeNativeEventDispatchDepth;
     private bool _isDisposed;
     private bool _isNativeLoopRunning;
     private bool _usesExternalNativeLoopPump;
@@ -1093,38 +1102,31 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             window.DoRender();
         }
 
+        Interlocked.Increment(ref s_activeNativeEventDispatchDepth);
         try
         {
             window.DoEvents();
+            if (!ShouldKeepPortableNativeRunLoopAlive())
+            {
+                DisposeDeferredNativeWindowIfNeeded();
+                return;
+            }
+
+            window.DoUpdate();
+            EnsureCompositionTargetLoaded();
+            if (ShouldPumpNativeRender())
+            {
+                NativeRenderPumpCount++;
+                window.DoRender();
+            }
+            else
+            {
+                SkippedNativeRenderPumpCount++;
+            }
         }
         finally
         {
-            ProcessDeferredNativeWindowDisposals();
-        }
-
-        if (!ShouldKeepPortableNativeRunLoopAlive())
-        {
-            DisposeDeferredNativeWindowIfNeeded();
-            return;
-        }
-
-        ProcessDispatcherQueueCore();
-        if (!ShouldKeepPortableNativeRunLoopAlive())
-        {
-            DisposeDeferredNativeWindowIfNeeded();
-            return;
-        }
-
-        window.DoUpdate();
-        EnsureCompositionTargetLoaded();
-        if (ShouldPumpNativeRender())
-        {
-            NativeRenderPumpCount++;
-            window.DoRender();
-        }
-        else
-        {
-            SkippedNativeRenderPumpCount++;
+            Interlocked.Decrement(ref s_activeNativeEventDispatchDepth);
         }
 
         DisposeDeferredNativeWindowIfNeeded();
@@ -1247,7 +1249,11 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
             (_isNativeLoopRunning ||
                 _isRendering ||
                 _isProcessingDispatcherWorkWakeup ||
-                _isInNativeWindowCloseCallback);
+                _isInNativeWindowCloseCallback ||
+                // Not just this instance's own reentrancy: GLFW's poll is process-global, so a
+                // *different* host's DoEvents() can be the one currently dispatching the native
+                // callback (e.g. a modal dialog's Cancel click) that led here.
+                Volatile.Read(ref s_activeNativeEventDispatchDepth) > 0);
         bool disposeNativeWindow = window != null && !deferNativeWindowDispose;
 
         if (window != null && !deferNativeWindowDispose)


### PR DESCRIPTION
## Summary

GLFW's event poll is process-global: whichever host instance calls `DoEvents()` dispatches pending native callbacks for **every** native window, not just its own. A callback can therefore synchronously `Close()`/`Dispose()` a *different* host than the one currently inside `DoEvents()/DoUpdate()/DoRender()`. The existing per-instance flags (`_isNativeLoopRunning`, `_isRendering`, ...) cannot see that, so `Dispose()` ends up calling Silk.NET's `Reset()` reentrantly — which Silk.NET explicitly forbids while any window's render loop is active, crashing the process.

This adds a process-wide `s_activeNativeEventDispatchDepth` counter incremented around the native event dispatch region and consulted by `Dispose()` when deciding whether to defer native-window disposal.

Observed as a hard crash when closing a modal dialog while the owner window's host was pumping events.

## Tests

- `ProGpuWpfWindowHostTests` source-shape assertions updated for the new guard.
- Full managed transport builds clean on macOS arm64.