### PR TITLE
[WIP] macOS drag and drop for portable windows

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -437,6 +437,7 @@
     <Compile Include="System\Windows\PortablePresentationSourceHost.cs" />
     <Compile Include="System\Windows\PresentationSource.cs" />
     <Compile Include="System\Windows\PortablePresentationSource.cs" />
+    <Compile Include="System\Windows\PortableDragDropOperation.cs" />
     <Compile Include="System\Windows\PortableVisualOwnerKind.cs" />
     <Compile Include="System\Windows\QueryContinueDragEventArgs.cs" />
     <Compile Include="System\Windows\QueryContinueDragEventHandler.cs" />

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragDrop.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/DragDrop.cs
@@ -401,13 +401,13 @@ namespace System.Windows
                 dataObject = new DataObject(data);
             }
 
-            // Portable presentation sources do not own an HWND/OLE message pump.  Calling
-            // OleDoDragDrop from their Silk.NET input callback would require a Windows STA
-            // and crashes on non-Windows hosts.  Fail closed until a portable source-drag
-            // service is available; incoming portable drops continue to use the typed
-            // ProcessPortableDragDrop path below.
+            // Portable presentation sources do not own an HWND/OLE message pump, so they can't
+            // drive OleDoDragDrop's native modal loop. PortableDragDropOperation replays the same
+            // source-side protocol (QueryContinueDrag/GiveFeedback, DragEnter/Over/Leave/Drop)
+            // without OLE, driven by a captured mouse and a nested DispatcherFrame instead - see
+            // that class for the full rationale.
             DragDropEffects ret = IsPortableDragSource(dragSource)
-                ? DragDropEffects.None
+                ? PortableDragDropOperation.Run(dragSource, dataObject, allowedEffects)
                 : OleDoDragDrop(dragSource, dataObject, allowedEffects);
 
             args = new RoutedEventArgs(DragDropCompletedEvent, dragSource);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
@@ -45,6 +45,8 @@ namespace System.Windows
         private DragDropEffects _lastEffects = DragDropEffects.None;
         private DragAction _action = DragAction.Continue;
         private bool _dropped;
+        private Point _lastRootPoint;
+        private bool _hasLastRootPoint;
 
         private PortableDragDropOperation(UIElement dragSource, PortablePresentationSource source, DataObject dataObject, DragDropEffects allowedEffects)
         {
@@ -115,12 +117,38 @@ namespace System.Windows
             _dragSource.PreviewMouseUp += onPreviewMouseButtonUp;
             _dragSource.PreviewKeyDown += onPreviewKeyDown;
 
+            // Safety net: the ONLY thing that normally ends this loop is a PreviewMouseUp/
+            // PreviewMouseMove routed event reaching _dragSource while it holds mouse capture. On
+            // Windows the OLE modal loop guarantees that delivery. Off Windows, real interactive
+            // drags have been observed to leave the button released at the OS level (Mouse.LeftButton
+            // already Released) without that routed event ever firing on _dragSource - e.g. capture
+            // getting silently redirected, or the up landing on a different element mid-drag - and
+            // with no timeout this loop then spins in Dispatcher's NativeInputPump/Thread.Sleep(1)
+            // forever, which is exactly an app hang a user has to force-quit to escape. Polling the
+            // global button state once per composed frame (~60Hz) closes that gap: catches a missed
+            // release within about one frame, while changing nothing when the routed event already
+            // fires normally (RaiseQueryContinueDrag's own zero-buttons-down check still drives the
+            // actual Drop decision).
+            EventHandler onRenderingTick = (_, _) =>
+            {
+                if (_action != DragAction.Continue || !_hasLastRootPoint)
+                    return;
+                if (Mouse.LeftButton == MouseButtonState.Released &&
+                    Mouse.MiddleButton == MouseButtonState.Released &&
+                    Mouse.RightButton == MouseButtonState.Released)
+                {
+                    OnPointerUpdate(frame, _lastRootPoint);
+                }
+            };
+            CompositionTarget.Rendering += onRenderingTick;
+
             try
             {
                 Dispatcher.PushFrame(frame);
             }
             finally
             {
+                CompositionTarget.Rendering -= onRenderingTick;
                 _dragSource.PreviewMouseMove -= onPreviewMouseMove;
                 _dragSource.PreviewMouseUp -= onPreviewMouseButtonUp;
                 _dragSource.PreviewKeyDown -= onPreviewKeyDown;
@@ -143,6 +171,9 @@ namespace System.Windows
         {
             if (_action != DragAction.Continue)
                 return;
+
+            _lastRootPoint = rootPoint;
+            _hasLastRootPoint = true;
 
             var keyStates = GetCurrentKeyStates();
             var query = new QueryContinueDragEventArgs(escapePressed: false, keyStates);
@@ -237,15 +268,39 @@ namespace System.Windows
             {
                 switch (current)
                 {
-                    case UIElement { AllowDrop: true } uiElement:
+                    case UIElement { AllowDrop: true } uiElement when IsExplicitlyDropEnabled(uiElement, UIElement.AllowDropProperty):
                         return uiElement;
-                    case ContentElement { AllowDrop: true } contentElement:
+                    case ContentElement { AllowDrop: true } contentElement when IsExplicitlyDropEnabled(contentElement, ContentElement.AllowDropProperty):
                         return contentElement;
-                    case UIElement3D { AllowDrop: true } uiElement3D:
+                    case UIElement3D { AllowDrop: true } uiElement3D when IsExplicitlyDropEnabled(uiElement3D, UIElement3D.AllowDropProperty):
                         return uiElement3D;
                 }
             }
             return null;
+        }
+
+        // AllowDropProperty carries FrameworkPropertyMetadataOptions.Inherits (this matches real
+        // WPF, not a portability difference - see FrameworkElement's static constructor). On
+        // Windows that is harmless: OLE's RegisterDragDrop is registered once per HWND, and
+        // OleDropTarget resolves the specific target through its own hit-testing, never by walking
+        // AllowDrop ancestors. This portable reimplementation instead approximates Windows' registered
+        // drop target by walking up for an AllowDrop==true ancestor - but with inheritance in play,
+        // EVERY descendant under any AllowDrop-enabled root reports AllowDrop==true, so the walk
+        // matched literally the first thing hit (an adorner, a ListBoxItem - anything) instead of the
+        // real intended container. A dragged toolbox item then silently never landed: DragEnter/
+        // DragOver fired on that incidental element, which usually has no Drop subscriber, so nothing
+        // happened and no error was ever surfaced.
+        //
+        // The fix: only accept a value that was actually placed on THIS element (Local, Style,
+        // Template, DefaultStyle, ParentTemplate, ...), never one that merely flowed down via
+        // Inherited. That is what "AllowDrop declared here" means on Windows too, since inheritance
+        // there is inert (nothing consults it).
+        private static bool IsExplicitlyDropEnabled(DependencyObject element, DependencyProperty property)
+        {
+            var source = element.GetValueSource(
+                property, null,
+                out _, out var isExpression, out var isAnimated, out var isCoerced, out _);
+            return source != BaseValueSourceInternal.Inherited || isExpression || isAnimated || isCoerced;
         }
 
         private static DependencyObject GetVisualOrLogicalParent(DependencyObject current)

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Media3D;
 using System.Windows.Threading;
 
 namespace System.Windows
@@ -58,6 +60,9 @@ namespace System.Windows
         /// <see cref="UIElement"/> with a live root visual (mirrors the old fail-closed behavior
         /// for every case this doesn't (yet) support).
         /// </summary>
+        [ThreadStatic]
+        private static bool s_isRunning;
+
         internal static DragDropEffects Run(DependencyObject dragSource, DataObject dataObject, DragDropEffects allowedEffects)
         {
             if (dragSource is not UIElement dragElement)
@@ -66,7 +71,27 @@ namespace System.Windows
             if (PresentationSource.CriticalFromVisual(dragSource) is not PortablePresentationSource source || source.RootVisual == null)
                 return DragDropEffects.None;
 
-            return new PortableDragDropOperation(dragElement, source, dataObject, allowedEffects).RunCore();
+            // Once a drag is under way, NativeInputPump (see Dispatcher.NativeInputPump's doc
+            // comment) keeps routing every subsequent native mouse-move through WPF's normal
+            // event system while nested inside this same operation's blocking wait - which means
+            // any OTHER handler still subscribed to the drag source's PreviewMouseMove (e.g. the
+            // very code that called DoDragDrop in the first place, like WpfToolbox's own
+            // OnPreviewMouseMove, which has no "already dragging" guard because real OLE's native
+            // modal loop would never let a second MouseMove reach it mid-drag) sees that event
+            // too and calls DoDragDrop again, recursively, before this operation ever gets to
+            // process it itself. Fail the reentrant call closed instead of nesting indefinitely.
+            if (s_isRunning)
+                return DragDropEffects.None;
+
+            s_isRunning = true;
+            try
+            {
+                return new PortableDragDropOperation(dragElement, source, dataObject, allowedEffects).RunCore();
+            }
+            finally
+            {
+                s_isRunning = false;
+            }
         }
 
         private DragDropEffects RunCore()
@@ -188,15 +213,47 @@ namespace System.Windows
 
         // Mirrors DragDrop.GetCurrentTarget's single-hit check (no ancestor walk) so a portable
         // drag targets exactly what a real Windows/OLE drag would - see OleDropTarget.GetCurrentTarget.
+        // Real OLE's GetCurrentTarget checks only the immediate hit, with no ancestor walk - that
+        // works on Windows because AllowDrop-enabled elements there are typically reached via a
+        // registered-HWND-wide hit test that lands on them directly. Here, the immediate hit is
+        // very often an adorner (resize/move handles, which sit on top of everything precisely so
+        // they ARE hit first) or the design surface's own root content element, neither of which
+        // is AllowDrop - the actual AllowDrop element (DesignPanel's EatAllHitTestRequests overlay,
+        // or an ancestor Panel a real click-then-hit-test sequence would normally reach once
+        // CreateComponentTool's own DragOver handler flips IsAdornerLayerHitTestVisible) is further
+        // up the tree. Walk up to find it instead of giving up on the first miss.
+        //
+        // Stop at the FIRST (innermost) AllowDrop match, matching real OLE's GetCurrentTarget as
+        // closely as this can - an "outermost" walk was tried and made things worse (walked past
+        // the real target, e.g. DesignPanel, to something even further out with no Drop
+        // subscriber either). Some intermediate elements can still end up AllowDrop=true for
+        // reasons unrelated to actually handling Drop (e.g. WpfDesign's PanelMoveAdorner, via a
+        // generic shared style) - if that turns out to matter in practice, the fix belongs at the
+        // caller/coordinate-choice level (pick a drop point that avoids hitting such an element),
+        // not by guessing at tree depth here.
         private static DependencyObject ResolveDropTarget(DependencyObject hit)
         {
-            return hit switch
+            for (DependencyObject current = hit; current != null; current = GetVisualOrLogicalParent(current))
             {
-                UIElement { AllowDrop: true } uiElement => uiElement,
-                ContentElement { AllowDrop: true } contentElement => contentElement,
-                UIElement3D { AllowDrop: true } uiElement3D => uiElement3D,
-                _ => null
-            };
+                switch (current)
+                {
+                    case UIElement { AllowDrop: true } uiElement:
+                        return uiElement;
+                    case ContentElement { AllowDrop: true } contentElement:
+                        return contentElement;
+                    case UIElement3D { AllowDrop: true } uiElement3D:
+                        return uiElement3D;
+                }
+            }
+            return null;
+        }
+
+        private static DependencyObject GetVisualOrLogicalParent(DependencyObject current)
+        {
+            // LogicalTreeHelper lives in PresentationFramework, not reachable from here - a
+            // visual-tree-only walk is enough for design-surface hit testing (adorners and
+            // DesignPanel's own overlay are all plain Visuals).
+            return current is Visual || current is Visual3D ? VisualTreeHelper.GetParent(current) : null;
         }
 
         private static DragDropKeyStates GetCurrentKeyStates()

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
@@ -1,0 +1,265 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace System.Windows
+{
+    /// <summary>
+    /// Portable (non-Windows, non-OLE) replacement for the source half of
+    /// <see cref="DragDrop.DoDragDrop"/>. Real WPF's drag source blocks on a Win32 OLE modal loop
+    /// (<c>OleServicesContext.OleDoDragDrop</c>) that pumps native mouse/keyboard messages and
+    /// calls back into <see cref="OleDragSource"/>/<see cref="OleDropTarget"/> as the pointer moves
+    /// over registered drop-target HWNDs. <see cref="PortablePresentationSource"/> has no HWND/OLE
+    /// message pump to drive that loop, so <see cref="DragDrop.DoDragDrop"/> previously "failed
+    /// closed" (returned <see cref="DragDropEffects.None"/> immediately) for portable sources -
+    /// meaning no WPF drag-and-drop (e.g. a toolbox item dragged onto a design surface) ever
+    /// actually ran off Windows.
+    ///
+    /// This reimplements the same source-side protocol without OLE: capture the mouse on the drag
+    /// source, push a nested <see cref="DispatcherFrame"/> so the call stays synchronous exactly
+    /// like the OLE path while still processing input, and on every mouse move hit-test the
+    /// portable source's visual tree (<see cref="MouseDevice.LocalHitTest"/>, which is already
+    /// source-agnostic) to find the current drop target - then drive the SAME
+    /// DragEnter/DragOver/DragLeave/Drop routed events real portable drop targets already handle
+    /// via <see cref="DragDrop.ProcessPortableDragDrop"/> (that half of the pipeline was already
+    /// built; only this source-side driver was missing). QueryContinueDrag/GiveFeedback are raised
+    /// with the same default fallback semantics <see cref="OleDragSource"/> uses on Windows, so a
+    /// handler written against the public DragDrop routed events behaves identically on both.
+    ///
+    /// Scoped to <see cref="UIElement"/> drag sources only (matches every current caller -
+    /// WpfToolbox's own drag source is a ListBox); <see cref="ContentElement"/>/
+    /// <see cref="UIElement3D"/> sources fail closed the same way the whole portable path used to.
+    /// </summary>
+    internal sealed class PortableDragDropOperation
+    {
+        private readonly UIElement _dragSource;
+        private readonly PortablePresentationSource _source;
+        private readonly DataObject _dataObject;
+        private readonly DragDropEffects _allowedEffects;
+
+        private DependencyObject _currentTarget;
+        private DragDropEffects _lastEffects = DragDropEffects.None;
+        private DragAction _action = DragAction.Continue;
+        private bool _dropped;
+
+        private PortableDragDropOperation(UIElement dragSource, PortablePresentationSource source, DataObject dataObject, DragDropEffects allowedEffects)
+        {
+            _dragSource = dragSource;
+            _source = source;
+            _dataObject = dataObject;
+            _allowedEffects = allowedEffects;
+        }
+
+        /// <summary>
+        /// Runs a portable drag-and-drop operation for <paramref name="dragSource"/>, or returns
+        /// <see cref="DragDropEffects.None"/> immediately if the source isn't a portable
+        /// <see cref="UIElement"/> with a live root visual (mirrors the old fail-closed behavior
+        /// for every case this doesn't (yet) support).
+        /// </summary>
+        internal static DragDropEffects Run(DependencyObject dragSource, DataObject dataObject, DragDropEffects allowedEffects)
+        {
+            if (dragSource is not UIElement dragElement)
+                return DragDropEffects.None;
+
+            if (PresentationSource.CriticalFromVisual(dragSource) is not PortablePresentationSource source || source.RootVisual == null)
+                return DragDropEffects.None;
+
+            return new PortableDragDropOperation(dragElement, source, dataObject, allowedEffects).RunCore();
+        }
+
+        private DragDropEffects RunCore()
+        {
+            if (!Mouse.Capture(_dragSource, CaptureMode.SubTree))
+                return DragDropEffects.None;
+
+            var frame = new DispatcherFrame();
+
+            MouseEventHandler onPreviewMouseMove = (sender, e) => OnPointerUpdate(frame, e.GetPosition((IInputElement)_source.RootVisual));
+            MouseButtonEventHandler onPreviewMouseButtonUp = (sender, e) => OnPointerUpdate(frame, e.GetPosition((IInputElement)_source.RootVisual));
+            KeyEventHandler onPreviewKeyDown = (sender, e) =>
+            {
+                if (e.Key != Key.Escape)
+                    return;
+                _action = DragAction.Cancel;
+                frame.Continue = false;
+            };
+
+            _dragSource.PreviewMouseMove += onPreviewMouseMove;
+            _dragSource.PreviewMouseUp += onPreviewMouseButtonUp;
+            _dragSource.PreviewKeyDown += onPreviewKeyDown;
+
+            try
+            {
+                Dispatcher.PushFrame(frame);
+            }
+            finally
+            {
+                _dragSource.PreviewMouseMove -= onPreviewMouseMove;
+                _dragSource.PreviewMouseUp -= onPreviewMouseButtonUp;
+                _dragSource.PreviewKeyDown -= onPreviewKeyDown;
+
+                if (ReferenceEquals(Mouse.Captured, _dragSource))
+                    Mouse.Capture(null);
+
+                if (_currentTarget != null && !_dropped)
+                {
+                    DragDrop.ProcessPortableDragDrop(
+                        _currentTarget, DragDrop.DragLeaveEvent, _dataObject,
+                        GetCurrentKeyStates(), _allowedEffects, DragDropEffects.None, default);
+                }
+            }
+
+            return _dropped ? _lastEffects : DragDropEffects.None;
+        }
+
+        private void OnPointerUpdate(DispatcherFrame frame, Point rootPoint)
+        {
+            if (_action != DragAction.Continue)
+                return;
+
+            var keyStates = GetCurrentKeyStates();
+            var query = new QueryContinueDragEventArgs(escapePressed: false, keyStates);
+            RaiseQueryContinueDrag(query);
+            _action = query.Action;
+
+            if (_action == DragAction.Cancel)
+            {
+                frame.Continue = false;
+                return;
+            }
+
+            var hit = MouseDevice.LocalHitTest(rootPoint, _source) as DependencyObject;
+            var target = ResolveDropTarget(hit);
+
+            if (!ReferenceEquals(target, _currentTarget))
+            {
+                if (_currentTarget != null)
+                {
+                    DragDrop.ProcessPortableDragDrop(
+                        _currentTarget, DragDrop.DragLeaveEvent, _dataObject,
+                        keyStates, _allowedEffects, DragDropEffects.None, default);
+                }
+
+                _currentTarget = target;
+
+                if (target != null)
+                {
+                    var targetPoint = InputElement.TranslatePoint(rootPoint, _source.RootVisual, target);
+                    _lastEffects = DragDrop.ProcessPortableDragDrop(
+                        target, DragDrop.DragEnterEvent, _dataObject,
+                        keyStates, _allowedEffects, DragDropEffects.None, targetPoint);
+                }
+                else
+                {
+                    _lastEffects = DragDropEffects.None;
+                }
+            }
+            else if (target != null)
+            {
+                var targetPoint = InputElement.TranslatePoint(rootPoint, _source.RootVisual, target);
+                _lastEffects = DragDrop.ProcessPortableDragDrop(
+                    target, DragDrop.DragOverEvent, _dataObject,
+                    keyStates, _allowedEffects, DragDropEffects.None, targetPoint);
+            }
+
+            var feedback = new GiveFeedbackEventArgs(_lastEffects, useDefaultCursors: true);
+            RaiseGiveFeedback(feedback);
+
+            if (_action == DragAction.Drop)
+            {
+                if (_currentTarget != null)
+                {
+                    var targetPoint = InputElement.TranslatePoint(rootPoint, _source.RootVisual, _currentTarget);
+                    _lastEffects = DragDrop.ProcessPortableDragDrop(
+                        _currentTarget, DragDrop.DropEvent, _dataObject,
+                        keyStates, _allowedEffects, DragDropEffects.None, targetPoint);
+                }
+                else
+                {
+                    _lastEffects = DragDropEffects.None;
+                }
+
+                _dropped = true;
+                frame.Continue = false;
+            }
+        }
+
+        // Mirrors DragDrop.GetCurrentTarget's single-hit check (no ancestor walk) so a portable
+        // drag targets exactly what a real Windows/OLE drag would - see OleDropTarget.GetCurrentTarget.
+        private static DependencyObject ResolveDropTarget(DependencyObject hit)
+        {
+            return hit switch
+            {
+                UIElement { AllowDrop: true } uiElement => uiElement,
+                ContentElement { AllowDrop: true } contentElement => contentElement,
+                UIElement3D { AllowDrop: true } uiElement3D => uiElement3D,
+                _ => null
+            };
+        }
+
+        private static DragDropKeyStates GetCurrentKeyStates()
+        {
+            DragDropKeyStates states = 0;
+
+            if (Mouse.LeftButton == MouseButtonState.Pressed)
+                states |= DragDropKeyStates.LeftMouseButton;
+            if (Mouse.RightButton == MouseButtonState.Pressed)
+                states |= DragDropKeyStates.RightMouseButton;
+            if (Mouse.MiddleButton == MouseButtonState.Pressed)
+                states |= DragDropKeyStates.MiddleMouseButton;
+            if ((Keyboard.Modifiers & ModifierKeys.Control) != 0)
+                states |= DragDropKeyStates.ControlKey;
+            if ((Keyboard.Modifiers & ModifierKeys.Shift) != 0)
+                states |= DragDropKeyStates.ShiftKey;
+            if ((Keyboard.Modifiers & ModifierKeys.Alt) != 0)
+                states |= DragDropKeyStates.AltKey;
+
+            return states;
+        }
+
+        // Same shape and default fallback as OleDragSource.RaiseQueryContinueDragEvent/
+        // OnDefaultQueryContinueDrag, just raised directly on the drag source element instead of
+        // through an IOleDropSource COM callback.
+        private void RaiseQueryContinueDrag(QueryContinueDragEventArgs args)
+        {
+            args.RoutedEvent = DragDrop.PreviewQueryContinueDragEvent;
+            _dragSource.RaiseEvent(args);
+
+            args.RoutedEvent = DragDrop.QueryContinueDragEvent;
+            if (!args.Handled)
+                _dragSource.RaiseEvent(args);
+
+            if (args.Handled)
+                return;
+
+            int mouseButtonDownCount = 0;
+            if ((args.KeyStates & DragDropKeyStates.LeftMouseButton) != 0)
+                mouseButtonDownCount++;
+            if ((args.KeyStates & DragDropKeyStates.MiddleMouseButton) != 0)
+                mouseButtonDownCount++;
+            if ((args.KeyStates & DragDropKeyStates.RightMouseButton) != 0)
+                mouseButtonDownCount++;
+
+            args.Action = DragAction.Continue;
+            if (args.EscapePressed || mouseButtonDownCount >= 2)
+                args.Action = DragAction.Cancel;
+            else if (mouseButtonDownCount == 0)
+                args.Action = DragAction.Drop;
+        }
+
+        private void RaiseGiveFeedback(GiveFeedbackEventArgs args)
+        {
+            args.RoutedEvent = DragDrop.PreviewGiveFeedbackEvent;
+            _dragSource.RaiseEvent(args);
+
+            args.RoutedEvent = DragDrop.GiveFeedbackEvent;
+            if (!args.Handled)
+                _dragSource.RaiseEvent(args);
+
+            if (!args.Handled)
+                args.UseDefaultCursors = true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
@@ -317,6 +317,26 @@ namespace System.Windows
 
             if (!args.Handled)
                 args.UseDefaultCursors = true;
+
+            // On Windows, DRAGDROP_S_USEDEFAULTCURSORS tells the OLE modal loop to draw its own
+            // native drag cursor - no WPF code is involved. There's no OLE here, so the portable
+            // path has to draw that feedback itself, or the mouse pointer never visibly changes
+            // while a drag is in progress (it just looks like nothing is happening).
+            if (args.UseDefaultCursors)
+                Mouse.SetCursor(GetDefaultDragCursor(args.Effects));
+        }
+
+        private static Cursor GetDefaultDragCursor(DragDropEffects effects)
+        {
+            if (effects == DragDropEffects.None)
+                return Cursors.No;
+            if ((effects & DragDropEffects.Copy) != 0)
+                return Cursors.Cross;
+            if ((effects & DragDropEffects.Move) != 0)
+                return Cursors.Hand;
+            if ((effects & DragDropEffects.Link) != 0)
+                return Cursors.Hand;
+            return Cursors.Arrow;
         }
     }
 }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/PortableDragDropOperation.cs
@@ -22,7 +22,7 @@ namespace System.Windows
     /// This reimplements the same source-side protocol without OLE: capture the mouse on the drag
     /// source, push a nested <see cref="DispatcherFrame"/> so the call stays synchronous exactly
     /// like the OLE path while still processing input, and on every mouse move hit-test the
-    /// portable source's visual tree (<see cref="MouseDevice.LocalHitTest"/>, which is already
+    /// portable source's visual tree (UIElement.InputHitTest on the root visual, which is already
     /// source-agnostic) to find the current drop target - then drive the SAME
     /// DragEnter/DragOver/DragLeave/Drop routed events real portable drop targets already handle
     /// via <see cref="DragDrop.ProcessPortableDragDrop"/> (that half of the pipeline was already
@@ -186,7 +186,15 @@ namespace System.Windows
                 return;
             }
 
-            var hit = MouseDevice.LocalHitTest(rootPoint, _source) as DependencyObject;
+            // rootPoint is already in RootVisual space (both handlers in RunCore compute it with
+            // GetPosition(_source.RootVisual)), so hit-test it directly. MouseDevice.LocalHitTest's
+            // (point, source) overload treats its point as CLIENT units and runs PointUtil.ClientToRoot
+            // over it first - double-transforming an already-root point, which then resolved the
+            // window's chrome Border instead of the element actually under the cursor. Measured at the
+            // same point mid-drag: InputHitTest said Canvas (the real AllowDrop target),
+            // LocalHitTest said Border, so ResolveDropTarget walked Border -> Window, found nothing
+            // AllowDrop, and every portable drag silently completed with no DragOver/Drop at all.
+            var hit = (_source.RootVisual as UIElement)?.InputHitTest(rootPoint) as DependencyObject;
             var target = ResolveDropTarget(hit);
 
             if (!ReferenceEquals(target, _currentTarget))

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PortableWindowActivationService.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/PortableWindowActivationService.cs
@@ -15,6 +15,7 @@ namespace System.Windows
     {
         private static readonly WindowActivationServiceRegistrar s_registrar = new WindowActivationServiceRegistrar();
         private static IDisposable s_registrarRegistration;
+        private static bool s_nativeInputPumpBridged;
         private static Func<object, object> _activate;
         private static Action<object> _show;
         private static Action<object> _hide;
@@ -44,6 +45,37 @@ namespace System.Windows
         internal static void RegisterPortableInteropService()
         {
             s_registrarRegistration ??= PortableWpfServiceRegistry.RegisterWindowActivationService(s_registrar);
+            EnsureNativeInputPumpBridged();
+        }
+
+        /// <summary>
+        /// Bridges the windowing layer's native event pump (published through
+        /// PortableWpfServiceRegistry, since ProGPU.Wpf only compiles against a WPF-shaped stub and
+        /// cannot assign the real Dispatcher.NativeInputPump directly) into
+        /// System.Windows.Threading.Dispatcher.NativeInputPump.
+        ///
+        /// Without this a nested Dispatcher.PushFrame has nothing to pump and returns as soon as
+        /// the managed queue drains, so anything that blocks on one - Window.ShowDialog, and
+        /// PortableDragDropOperation's whole drag-source loop - never observes the input it is
+        /// waiting for. Subscribing (rather than only reading once) covers both orderings: this
+        /// runs during PresentationFramework init, which can be before or after ProGPU.Wpf
+        /// registers its pump.
+        /// </summary>
+        private static void EnsureNativeInputPumpBridged()
+        {
+            if (s_nativeInputPumpBridged)
+            {
+                return;
+            }
+
+            s_nativeInputPumpBridged = true;
+            PortableWpfServiceRegistry.NativeInputPumpChanged += static (_, _) => ApplyNativeInputPump();
+            ApplyNativeInputPump();
+        }
+
+        private static void ApplyNativeInputPump()
+        {
+            Dispatcher.NativeInputPump = PortableWpfServiceRegistry.NativeInputPump;
         }
 
         internal static void Register(

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/System/Windows/Threading/Dispatcher.cs
@@ -19,6 +19,23 @@ namespace System.Windows.Threading
     /// </summary>
     public sealed class Dispatcher
     {
+        /// <summary>
+        /// Set once by the portable windowing layer (ProGPU.Wpf's WpfPortableWindowActivation,
+        /// which owns the ProGpuWpfWindowHost instances Dispatcher/WindowsBase can't reference
+        /// directly) to pump every active window's native event queue - Silk.NET IMouse/IKeyboard
+        /// callbacks, which drive WPF's own input pipeline, only fire as a direct result of a
+        /// pump call like this, never asynchronously from another thread.
+        ///
+        /// A NESTED PushFrame (Window.ShowDialog, DragDrop's portable drag-source loop, or any
+        /// other caller that needs to genuinely block until frame.Continue becomes false) used to
+        /// exit almost immediately whenever the managed dispatcher queue was momentarily empty -
+        /// correct for the TOP-level frame (which isn't driven through PushFrame at all; the
+        /// native window's own run loop keeps calling ProcessDispatcherQueueCore() on every tick
+        /// regardless), but wrong for a nested one genuinely waiting on new input that can only
+        /// arrive via this pump. See PushManagedFrameImpl's wait loop.
+        /// </summary>
+        public static Action NativeInputPump { get; set; }
+
         static Dispatcher()
         {
             _useWin32MessagePump = OperatingSystem.IsWindows();
@@ -2127,6 +2144,15 @@ namespace System.Windows.Threading
                         if (HasPendingManagedOperation())
                         {
                             ProcessQueue();
+                        }
+                        else if (frame.Continue && NativeInputPump != null)
+                        {
+                            // See NativeInputPump's doc comment: only take this path when a
+                            // pump is actually registered, so a caller that never opted in keeps
+                            // the exact original (non-blocking) behavior.
+                            NativeInputPump();
+                            if (!HasPendingManagedOperation())
+                                Thread.Sleep(1);
                         }
                         else
                         {

--- a/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
+++ b/src/Microsoft.DotNet.Wpf/src/WindowsBase/ref/WindowsBase.cs
@@ -1763,6 +1763,7 @@ namespace System.Windows.Threading
         public TResult Invoke<TResult>(System.Func<TResult> callback, System.Windows.Threading.DispatcherPriority priority) { throw null; }
         public TResult Invoke<TResult>(System.Func<TResult> callback, System.Windows.Threading.DispatcherPriority priority, System.Threading.CancellationToken cancellationToken) { throw null; }
         public TResult Invoke<TResult>(System.Func<TResult> callback, System.Windows.Threading.DispatcherPriority priority, System.Threading.CancellationToken cancellationToken, System.TimeSpan timeout) { throw null; }
+        public static System.Action NativeInputPump { get { throw null; } set { } }
         public static void PushFrame(System.Windows.Threading.DispatcherFrame frame) { }
         public static void Run() { }
         public static void ValidatePriority(System.Windows.Threading.DispatcherPriority priority, string parameterName) { }

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19280,6 +19280,32 @@ public sealed class WpfManagedProjectGraphTests
             item => string.Equals(item.Attribute("Include")?.Value, include, StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void PortableDragDropHonorsExplicitAllowDropAndDrawsDefaultCursors()
+    {
+        var dragDropOperation = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationCore",
+            "System",
+            "Windows",
+            "PortableDragDropOperation.cs"));
+
+        // An inherited AllowDrop=true made hit-testing match the first element touched
+        // (adorner, ListBoxItem - anything), so drops silently landed nowhere. Only a
+        // value placed on THIS element (or an expression/animation/coercion) counts -
+        // on Windows inheritance is inert because nothing consults it.
+        Assert.Contains("private static bool IsExplicitlyDropEnabled(DependencyObject element, DependencyProperty property)", dragDropOperation, StringComparison.Ordinal);
+        Assert.Contains("return source != BaseValueSourceInternal.Inherited || isExpression || isAnimated || isCoerced;", dragDropOperation, StringComparison.Ordinal);
+
+        // There is no OLE modal loop off-Windows, so GiveFeedback must draw the default
+        // drag cursors itself or the pointer never visibly changes during a drag.
+        Assert.Contains("if (args.UseDefaultCursors)\n                Mouse.SetCursor(GetDefaultDragCursor(args.Effects));", dragDropOperation, StringComparison.Ordinal);
+        Assert.Contains("private static Cursor GetDefaultDragCursor(DragDropEffects effects)", dragDropOperation, StringComparison.Ordinal);
+        Assert.Contains("if ((effects & DragDropEffects.Copy) != 0)\n                return Cursors.Cross;", dragDropOperation, StringComparison.Ordinal);
+    }
+
     private static void AssertGuardBefore(string source, string guard, string guardedCall)
     {
         var guardIndex = source.IndexOf(guard, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19306,6 +19306,77 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("if ((effects & DragDropEffects.Copy) != 0)\n                return Cursors.Cross;", dragDropOperation, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void PortableDragDropHitTestsRootPointDirectlyInsteadOfDoubleTransformingIt()
+    {
+        var dragDropOperation = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationCore",
+            "System",
+            "Windows",
+            "PortableDragDropOperation.cs"));
+
+        // rootPoint is already in RootVisual space (GetPosition(_source.RootVisual) in both
+        // handlers in RunCore). MouseDevice.LocalHitTest(point, source) instead treats its point
+        // as CLIENT units and runs PointUtil.ClientToRoot over it first - double-transforming an
+        // already-root point, which resolved the window's own chrome Border instead of the
+        // element actually under the cursor, so ResolveDropTarget never found an AllowDrop target
+        // and every portable drag completed silently with no DragOver/Drop at all.
+        Assert.Contains("var hit = (_source.RootVisual as UIElement)?.InputHitTest(rootPoint) as DependencyObject;", dragDropOperation, StringComparison.Ordinal);
+        Assert.DoesNotContain("MouseDevice.LocalHitTest(rootPoint, _source)", dragDropOperation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NativeInputPumpIsWiredFromWindowingLayerThroughToDispatcher()
+    {
+        var activation = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "WpfPortableWindowActivation.cs"));
+
+        // Dispatcher.NativeInputPump exists so a nested PushFrame (ShowDialog,
+        // PortableDragDropOperation's drag-source loop) can block waiting for real native input -
+        // but nothing assigned it, so every such frame exited within milliseconds having pumped
+        // zero input. ProGPU.Wpf can't assign Dispatcher.NativeInputPump directly (it compiles
+        // against a WPF-shaped stub, not the real WindowsBase it runs against - and reflection is
+        // off the table here, see ProGpuWpfProductSourceStaysFreeOfReflectionMarkers), so it
+        // publishes the pump through PortableWpfServiceRegistry instead.
+        Assert.Contains("PortableWpfServiceRegistry.NativeInputPump ??= PumpActiveHostNativeEvents;", activation, StringComparison.Ordinal);
+        AssertGuardBefore(activation, "PortableWpfServiceRegistry.NativeInputPump ??= PumpActiveHostNativeEvents;", "activationService.Register(CreateWindowActivationCallbacks(hostFactory));");
+
+        // The pump itself must reach every active window, not just whichever host currently owns
+        // the native run loop, and must not let one host's disposal race blow up the pump tick.
+        Assert.Contains("foreach (var host in GetActiveHosts())", activation, StringComparison.Ordinal);
+        Assert.Contains("host.DoEvents();", activation, StringComparison.Ordinal);
+
+        var registry = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Wpf.Interop",
+            "PortableWpfServiceRegistry.cs"));
+
+        Assert.Contains("public static Action? NativeInputPump", registry, StringComparison.Ordinal);
+        Assert.Contains("public static event EventHandler? NativeInputPumpChanged;", registry, StringComparison.Ordinal);
+
+        var portableActivationService = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationFramework",
+            "System",
+            "Windows",
+            "PortableWindowActivationService.cs"));
+
+        // The far end of the bridge - PresentationFramework compiles against the REAL Dispatcher,
+        // so this direction needs no reflection at all, just an event subscription (covering
+        // either registration order between ProGPU.Wpf and PresentationFramework).
+        Assert.Contains("PortableWpfServiceRegistry.NativeInputPumpChanged += static (_, _) => ApplyNativeInputPump();", portableActivationService, StringComparison.Ordinal);
+        Assert.Contains("Dispatcher.NativeInputPump = PortableWpfServiceRegistry.NativeInputPump;", portableActivationService, StringComparison.Ordinal);
+    }
+
     private static void AssertGuardBefore(string source, string guard, string guardedCall)
     {
         var guardIndex = source.IndexOf(guard, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
+++ b/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
@@ -185,6 +185,35 @@ public sealed class WpfPortableWindowActivation : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// Every currently-tracked window's host, for a caller that needs to pump native events
+    /// across all of them (e.g. wiring up System.Windows.Threading.Dispatcher.NativeInputPump -
+    /// see that property's doc comment in WindowsBase for why a nested Dispatcher.PushFrame needs
+    /// this). Deliberately takes no dependency on System.Windows.Threading itself: this project
+    /// only sees a minimal WPF-shaped compile-time stub (external/ProGPU/src/WindowsBase), not the
+    /// real Microsoft.DotNet.Wpf-based WindowsBase this actually runs against - the caller wiring
+    /// Dispatcher.NativeInputPump has to be a project that references the real one instead.
+    /// </summary>
+    public static ProGpuWpfWindowHost[] GetActiveHosts()
+    {
+        WeakReference<WpfPortableWindowActivation>[] activations;
+        lock (s_activeActivationsByHandleLock)
+        {
+            activations = new WeakReference<WpfPortableWindowActivation>[s_activeActivationsByHandle.Count];
+            s_activeActivationsByHandle.Values.CopyTo(activations, 0);
+        }
+
+        var hosts = new List<ProGpuWpfWindowHost>(activations.Length);
+        foreach (var weakActivation in activations)
+        {
+            if (weakActivation.TryGetTarget(out var activation) && !activation._isDisposed)
+            {
+                hosts.Add(activation.Host);
+            }
+        }
+        return hosts.ToArray();
+    }
+
     internal static bool TryGetActiveHost(object? window, out ProGpuWpfWindowHost? host)
     {
         if (window != null &&

--- a/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
+++ b/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
@@ -107,6 +107,7 @@ public sealed class WpfPortableWindowActivation : IDisposable
         {
             s_displayMetricsRegistration ??=
                 PortableWpfServiceRegistry.RegisterDisplayMetricsSource(s_displayMetricsSource);
+            PortableWpfServiceRegistry.NativeInputPump ??= PumpActiveHostNativeEvents;
             activationService.Register(CreateWindowActivationCallbacks(hostFactory));
             TryRegisterPresentationFrameworkLauncherService();
             TryRegisterPresentationFrameworkMessageBoxService();
@@ -212,6 +213,33 @@ public sealed class WpfPortableWindowActivation : IDisposable
             }
         }
         return hosts.ToArray();
+    }
+
+    /// <summary>
+    /// Pumps every active window's native event queue once - see
+    /// <see cref="PortableWpfServiceRegistry.NativeInputPump"/> for why the Dispatcher needs this.
+    ///
+    /// A single host's DoEvents() already dispatches native callbacks for every native window, and
+    /// the host's own reentrancy guards make the extra calls cheap no-ops, so iterating is about
+    /// not depending on which host happens to own the native loop right now. Per-host failures are
+    /// swallowed deliberately: a host racing into disposal on another thread must not turn a pump
+    /// tick into an exception escaping through the dispatcher frame that called it.
+    /// </summary>
+    private static void PumpActiveHostNativeEvents()
+    {
+        foreach (var host in GetActiveHosts())
+        {
+            try
+            {
+                host.DoEvents();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
     }
 
     internal static bool TryGetActiveHost(object? window, out ProGpuWpfWindowHost? host)


### PR DESCRIPTION
## Summary

Implements OLE-free drag-and-drop for portable windows on macOS, where there is no `DoDragDrop` modal loop to lean on:

- New `PortableDragDropOperation` (PresentationCore) drives the drag: raises GiveFeedback, maps `DragDropEffects` to default cursors (No/Cross/Hand/Arrow), and completes with the drop outcome.
- `AllowDrop` is now honored only when declared **on** the drop target. An inherited `AllowDrop=true` previously made hit-testing match the first element touched (adorner, ListBoxItem — anything): DragEnter/DragOver fired on that incidental element, which usually has no Drop subscriber, so drops silently did nothing. On Windows inheritance is inert because nothing consults it; this restores that semantic.
- Wires the operation through `WpfPortableWindowActivation` so hosts route native mouse input into the drag loop.

### Update: the drag loop now actually reaches DragOver/Drop

The above got a real drop target hit at least once, but two bugs meant the loop never got there in practice - confirmed live with a from-scratch portable WPF app driving real synthetic mouse input end to end:

- **`Dispatcher.NativeInputPump` was never assigned.** It exists specifically so a nested `Dispatcher.PushFrame` (`Window.ShowDialog`, `PortableDragDropOperation`'s whole drag-source loop) can block on real native input instead of returning the instant the managed dispatcher queue drains — but nothing wired it up, so every such frame exited within milliseconds having pumped zero input. `WpfPortableWindowActivation` now publishes a pump through a new `PortableWpfServiceRegistry.NativeInputPump` seam (**depends on [wieslawsoltes/ProGPU#142](https://github.com/wieslawsoltes/ProGPU/pull/142)**, since `ProGPU.Wpf` can't assign the real `Dispatcher.NativeInputPump` directly — it only compiles against a WPF-shaped stub, and reflection is off the table per `ProGpuWpfProductSourceStaysFreeOfReflectionMarkers`); `PortableWindowActivationService` in PresentationFramework bridges that into the real `Dispatcher.NativeInputPump`.
- **`OnPointerUpdate` double-transformed its hit-test point.** `rootPoint` is already in `RootVisual` space, but `MouseDevice.LocalHitTest(point, source)` treats its point as CLIENT units and re-runs `PointUtil.ClientToRoot` over it — resolving the window's own chrome `Border` instead of the element actually under the cursor. `ResolveDropTarget` then walked from `Border` up to the `Window`, found nothing `AllowDrop`, and every portable drag completed silently with no `DragEnter`/`DragOver`/`Drop` at all. Now hit-tests via `UIElement.InputHitTest` on the root visual directly.

## Tests

- `ProGPU.Wpf.SdkExternalSmokeHarness` exercises the cross-framework drag path.
- Full managed transport builds clean on macOS arm64.
- New graph tests (`WpfManagedProjectGraphTests`) pin down both fixes structurally; verified against the actual pre-fix/post-fix behavior via a standalone repro app driving the DevFlow agent's real synthetic mouse input (press/drag-move/release), not just source inspection.