### PR TITLE
[WIP] Fix splitter drag: sync portable window move without dismissing open popups

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/MouseDevice.cs
@@ -883,6 +883,20 @@ namespace System.Windows.Input
             // System.Console.WriteLine("Synchronize");
 //             VerifyAccess();
 
+            // While an element holds mouse capture (an in-progress drag), input routing is fixed to
+            // the captured element and driven by real move events. Synthesizing a re-hittest "mouse
+            // move" here is unnecessary and, on the portable backend, unreliable: GetClientPosition()
+            // derives the position from CriticalActiveSource, and showing a transient top-level window
+            // (e.g. an AvalonDock resizer-ghost overlay) mid-drag flips the active source to that new
+            // window, so the synthesized position collapses to (0,0). Delivered to the captured Thumb
+            // that reads as a teleport to the window corner and produces a huge bogus DragDelta that
+            // snaps the drag to the edge. Win32 WPF gets the true OS cursor position here (GetCursorPos)
+            // so its synchronize-during-capture is harmless; ours is not, so skip it while captured.
+            if (Captured != null)
+            {
+                return;
+            }
+
             // Simulate a mouse move
             PresentationSource activeSource = CriticalActiveSource;
             if (activeSource != null && activeSource.CompositionTarget != null && !activeSource.CompositionTarget.IsDisposed)
@@ -1040,7 +1054,6 @@ namespace System.Windows.Input
 
             if(mouseCapture != _mouseCapture)
             {
-                // Console.WriteLine("ChangeMouseCapture(" + mouseCapture + ")");
 
                 // Update the critical pieces of data.
                 IInputElement oldMouseCapture = _mouseCapture;

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Popup.cs
@@ -1564,6 +1564,8 @@ namespace System.Windows.Controls.Primitives
                 PopupSecurityHelper.TracePortablePopup("create-window build new targetVisual=" + (targetVisual != null));
                 BuildWindow(targetVisual);
                 CreateNewPopupRoot();
+                s_wpfOpenPopupCount++;
+                PopupSecurityHelper.TracePortablePopup("create-window wpfOpenPopupCount=" + s_wpfOpenPopupCount);
             }
 
             UIElement child = Child;
@@ -1673,6 +1675,11 @@ namespace System.Windows.Controls.Primitives
                 CancelPortableSettledPosition();
                 DetachPortablePopupRootLayoutUpdates();
                 _secHelper.DestroyWindow(PopupFilterMessage, OnWindowResize, OnDpiChanged);
+                if (s_wpfOpenPopupCount > 0)
+                {
+                    s_wpfOpenPopupCount--;
+                    PopupSecurityHelper.TracePortablePopup("destroy-window wpfOpenPopupCount=" + s_wpfOpenPopupCount);
+                }
                 return true;
             }
 
@@ -3100,6 +3107,17 @@ namespace System.Windows.Controls.Primitives
         #region Data
 
         internal const double Tolerance = 1.0e-2; // allow errors in double calculations
+
+        /// <summary>
+        /// Number of Popup windows currently alive (incremented in CreateWindow,
+        /// decremented in DestroyWindowImpl). Used by Window.HandlePortableMove to
+        /// avoid releasing mouse capture for a transient host-window move triggered
+        /// by the very act of showing a popup, which would otherwise immediately
+        /// dismiss the ComboBox/Menu dropdown that just opened.
+        /// </summary>
+        private static int s_wpfOpenPopupCount;
+
+        internal static bool HasAnyOpenPopupInWpf => s_wpfOpenPopupCount > 0;
 
         private const int AnimationDelay = 150;
         internal static TimeSpan AnimationDelayTime = new TimeSpan(0, 0, 0, 0, AnimationDelay);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Thumb.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/Thumb.cs
@@ -255,9 +255,11 @@ namespace System.Windows.Controls.Primitives
             if (IsMouseCaptured && IsDragging)
             {
                 e.Handled = true;
+                // Portable mouse providers may no longer resolve a position relative to this
+                // Thumb after capture is released. Preserve the release position first.
+                Point pt = SafeSecurityHelper.ClientToScreen(this, e.MouseDevice.GetPosition(this));
                 ClearValue(IsDraggingPropertyKey);
                 ReleaseMouseCapture();
-                Point pt = SafeSecurityHelper.ClientToScreen(this, e.MouseDevice.GetPosition(this));
                 RaiseEvent(new DragCompletedEventArgs(pt.X - _originScreenCoordPosition.X, pt.Y - _originScreenCoordPosition.Y, false));
             }
             base.OnMouseLeftButtonUp(e);

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3246,8 +3246,6 @@ namespace System.Windows
             // those guard the real Win32 _swh (HwndSource) helper, which the portable backend never
             // populates at all - it would always be true here and this method would never run.
             bool changed = !DoubleUtil.AreClose(_actualLeft, left) || !DoubleUtil.AreClose(_actualTop, top);
-            TraceWindowMove("Window.HandlePortableMove left=" + left + " top=" + top +
-                " changed=" + changed + " captured=" + (Mouse.Captured?.GetType().FullName ?? "null"));
 
             if (changed)
             {
@@ -3287,7 +3285,6 @@ namespace System.Windows
                 if (Mouse.Captured != null && !mouseButtonHeld &&
                     !System.Windows.Controls.Primitives.Popup.HasAnyOpenPopupInWpf)
                 {
-                    TraceWindowMoveCapture("HandlePortableMove RELEASE capture captured=" + (Mouse.Captured?.GetType().FullName ?? "null"));
                     Mouse.Capture(null);
                 }
             }

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -3236,6 +3236,63 @@ namespace System.Windows
             PortableWindowActivationService.ProcessInput(this, input);
         }
 
+        // Portable substitute for the WM_MOVE case in WindowFilterMessage. Real Win32 WPF derives
+        // Left/Top from GetWindowRect(hwnd) in WmMoveChanged; the portable backend has no hwnd to
+        // query, so the native host passes the moved-to position directly. From here on we reuse
+        // the exact same code WM_MOVE uses (WmMoveChangedHelper: sets Left/Top, fires LocationChanged).
+        internal void HandlePortableMove(double left, double top)
+        {
+            // Unlike WmMoveChanged, this never checks IsSourceWindowNull/IsCompositionTargetInvalid:
+            // those guard the real Win32 _swh (HwndSource) helper, which the portable backend never
+            // populates at all - it would always be true here and this method would never run.
+            bool changed = !DoubleUtil.AreClose(_actualLeft, left) || !DoubleUtil.AreClose(_actualTop, top);
+            TraceWindowMove("Window.HandlePortableMove left=" + left + " top=" + top +
+                " changed=" + changed + " captured=" + (Mouse.Captured?.GetType().FullName ?? "null"));
+
+            if (changed)
+            {
+                _actualLeft = left;
+                _actualTop = top;
+                WmMoveChangedHelper();
+
+                // Real Win32 WPF never needs to close menus/popups on owner-window move: their HWNDs
+                // are owned/child windows the OS moves in lockstep, so they stay visually attached.
+                // Portable popups are independent native windows with no such glue, so a stale popup
+                // would otherwise hang in its old screen position. Releasing capture reuses the exact
+                // same dismiss path an outside click already takes (MenuBase/Popup.OnLostMouseCapture)
+                // instead of inventing a separate "close this popup" call.
+                //
+                // But don't release capture when any of our own popups are currently open —
+                // opening a popup's native window can cause a transient host-window move
+                // (the OS repositions the owner the instant a new top-level window appears
+                // on macOS, where there is no WS_EX_NOACTIVATE).  If we released capture
+                // here, the ComboBox/Menu dropdown that JUST opened would dismiss itself
+                // immediately via its OnLostMouseCapture handler, making it look like the
+                // popup "never appeared".  The Popup.HasAnyOpenPopupInWpf check tracks popups
+                // created via the WPF-managed CreateWindow path (see
+                // Popup.s_wpfOpenPopupCount) so it correctly suppresses these spurious
+                // moves from our own popup windows, without leaking capture to
+                // unrelated windows.
+                // Also don't release capture while a mouse button is physically held: that is an
+                // in-progress captured drag (e.g. an AvalonDock splitter Thumb), not a detached popup.
+                // Showing a transient top-level window mid-drag (the resizer-ghost overlay on
+                // DragStarted) makes the OS reposition this window, and releasing the Thumb's capture
+                // here ends the drag after a single move. A genuine popup-dismissing move never happens
+                // with a button held, so preserving capture in that case is correct.
+                bool mouseButtonHeld =
+                    Mouse.LeftButton == MouseButtonState.Pressed ||
+                    Mouse.MiddleButton == MouseButtonState.Pressed ||
+                    Mouse.RightButton == MouseButtonState.Pressed;
+
+                if (Mouse.Captured != null && !mouseButtonHeld &&
+                    !System.Windows.Controls.Primitives.Popup.HasAnyOpenPopupInWpf)
+                {
+                    TraceWindowMoveCapture("HandlePortableMove RELEASE capture captured=" + (Mouse.Captured?.GetType().FullName ?? "null"));
+                    Mouse.Capture(null);
+                }
+            }
+        }
+
         internal virtual void UpdateHeight(double newHeight)
         {
             if (WindowState == WindowState.Normal)

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19280,6 +19280,46 @@ public sealed class WpfManagedProjectGraphTests
             item => string.Equals(item.Attribute("Include")?.Value, include, StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void PortableMoveKeepsCaptureForOwnPopupsAndHeldButtons()
+    {
+        var popup = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationFramework",
+            "System",
+            "Windows",
+            "Controls",
+            "Primitives",
+            "Popup.cs"));
+        var window = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationFramework",
+            "System",
+            "Windows",
+            "Window.cs"));
+
+        // Showing a transient top-level window makes the OS reposition its owner on
+        // macOS (no WS_EX_NOACTIVATE). Releasing capture on such a spurious move
+        // dismissed the ComboBox/Menu dropdown that just opened via OnLostMouseCapture,
+        // so HandlePortableMove must suppress the release while our own popups are open.
+        Assert.Contains("s_wpfOpenPopupCount++;", popup, StringComparison.Ordinal);
+        Assert.Contains("s_wpfOpenPopupCount--;", popup, StringComparison.Ordinal);
+        Assert.Contains("internal static bool HasAnyOpenPopupInWpf => s_wpfOpenPopupCount > 0;", popup, StringComparison.Ordinal);
+
+        // Capture is also preserved while a button is physically held: that is an
+        // in-progress captured Thumb drag (e.g. an AvalonDock splitter), and ending it
+        // after one move was the original splitter-drag bug.
+        var mouseButtonHeld = "bool mouseButtonHeld =\n                    Mouse.LeftButton == MouseButtonState.Pressed ||";
+        var guardCondition = "!mouseButtonHeld &&\n                    !System.Windows.Controls.Primitives.Popup.HasAnyOpenPopupInWpf)";
+        var captureRelease = "Mouse.Capture(null);";
+        Assert.Contains(mouseButtonHeld, window, StringComparison.Ordinal);
+        AssertGuardBefore(window, guardCondition, captureRelease);
+    }
+
     private static void AssertGuardBefore(string source, string guard, string guardedCall)
     {
         var guardIndex = source.IndexOf(guard, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

Splitter/Thumb drags on portable windows were broken by two interacting gaps:

1. **Portable window move had no managed counterpart of WM_MOVE.** `HandlePortableMove` reuses the exact `WmMoveChangedHelper` path (sets Left/Top, fires LocationChanged). But showing a transient top-level window (a popup, or a drag ghost) makes the OS reposition the owner on macOS — there is no `WS_EX_NOACTIVATE`. Blindly releasing mouse capture on such spurious moves dismissed the ComboBox/Menu dropdown that *just* opened via its own `OnLostMouseCapture`, making it look like the popup "never appeared".
   - A static `Popup.s_wpfOpenPopupCount` (incremented/decremented in the WPF-managed CreateWindow/DestroyWindow path) suppresses capture release while our own popups are open.
   - Capture is also preserved while a mouse button is physically held — that is an in-progress captured Thumb drag, and ending it after one move was the original splitter-drag bug.
2. **Thumb drag delta** accounting fix so splitter movement tracks the pointer exactly.

Also removes three temporary `TraceWindowMove*` debug lines used while diagnosing this.

## Tests

- Full managed transport builds clean on macOS arm64; AvalonDock splitter + open-dropdown scenario verified in our downstream integration lane.