### PR TITLE
[WIP] Packaging: suppressible runtime asset copy + GeneratePathProperty + Win32 compat shim exports

### DIFF
--- a/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.Win32Compat.c
+++ b/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.Win32Compat.c
@@ -454,6 +454,36 @@ PROGPU_EXPORT uint32_t GetCurrentProcessId(void)
 #endif
 }
 
+/* 0x0409 = en-US - a fixed, non-Arabic/non-Japanese LCID is enough for callers like
+   System.Drawing.SystemFonts.DefaultFont/DialogFont, which only special-case those two locales
+   before falling through to their own portable (non-locale-dependent) font selection. */
+#define PROGPU_LCID_EN_US 0x0409u
+
+PROGPU_EXPORT uint32_t GetSystemDefaultLCID(void)
+{
+    return PROGPU_LCID_EN_US;
+}
+
+PROGPU_EXPORT uint32_t GetUserDefaultLCID(void)
+{
+    return PROGPU_LCID_EN_US;
+}
+
+PROGPU_EXPORT uint32_t GetThreadLocale(void)
+{
+    return PROGPU_LCID_EN_US;
+}
+
+PROGPU_EXPORT uint16_t GetSystemDefaultLangID(void)
+{
+    return (uint16_t)PROGPU_LCID_EN_US;
+}
+
+PROGPU_EXPORT uint16_t GetUserDefaultLangID(void)
+{
+    return (uint16_t)PROGPU_LCID_EN_US;
+}
+
 PROGPU_EXPORT void Sleep(uint32_t milliseconds)
 {
     struct timespec requested;
@@ -1351,6 +1381,36 @@ PROGPU_EXPORT progpu_intptr GetStockObject(int32_t object)
 {
     (void)object;
     return 1;
+}
+
+/* GetStockObject above returns a fake handle with no real backing GDI object to introspect - so
+   GetObject (used e.g. by System.Drawing.Font.FromHfont to read a LOGFONT back out of an HFONT)
+   can only ever fail here. Returning 0 (the real Win32 failure signal) rather than pretending to
+   fill in the output struct lets callers' OWN existing fallback paths run - e.g.
+   System.Drawing.SystemFonts.DefaultFont already catches ArgumentException from a failed
+   Font.FromHfont and falls through to its next candidate (Tahoma, then GenericSansSerif). */
+PROGPU_EXPORT int32_t GetObjectA(progpu_intptr gdi_object, int32_t buffer_size, void* buffer)
+{
+    (void)gdi_object;
+    (void)buffer_size;
+    (void)buffer;
+    return 0;
+}
+
+PROGPU_EXPORT int32_t GetObjectW(progpu_intptr gdi_object, int32_t buffer_size, void* buffer)
+{
+    (void)gdi_object;
+    (void)buffer_size;
+    (void)buffer;
+    return 0;
+}
+
+PROGPU_EXPORT int32_t GetObject(progpu_intptr gdi_object, int32_t buffer_size, void* buffer)
+{
+    (void)gdi_object;
+    (void)buffer_size;
+    (void)buffer;
+    return 0;
 }
 
 PROGPU_EXPORT int32_t DeleteObject(progpu_intptr object)

--- a/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.targets
+++ b/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.targets
@@ -499,6 +499,20 @@
         Condition="'$(ProGpuWpfUseLibreWinForms)' == 'true' And '$(_ProGpuWpfPackageRoot)' != '' And '$(_ProGpuWpfPortableWinFormsCompatRuntimeTfm)' != '' And Exists('$(_ProGpuWpfPackageRoot)librewinforms.windowsformsintegration/$(ProGpuWpfLibreWinFormsPackageVersion)/lib/$(_ProGpuWpfPortableWinFormsCompatRuntimeTfm)/WindowsFormsIntegration.dll')" />
     </ItemGroup>
 
+    <!--
+      Tried (and reverted) a blanket force-copy of ProGPU.System.Drawing.Common here for every
+      UseWindowsForms=true project: the real (Microsoft-authored) System.Drawing.Common's
+      Font.FromHfont throws PlatformNotSupportedException unconditionally off Windows (called by
+      every System.Windows.Forms.Control's constructor via SystemFonts.DefaultFont - a deliberate
+      managed-code guard in dotnet/runtime, not a missing P/Invoke a shim could paper over), which
+      made the swap look necessary. But swapping the assembly identity wholesale broke OTHER,
+      unrelated code (e.g. WorkbenchStartup.InitializeWorkbench) that's compiled against and needs
+      the REAL assembly's exact identity (Version=10.0.0.0) for something else entirely - one
+      process can't have both under the same simple name. The real fix belongs at the actual
+      failure site instead: LibreWinForms.System.Windows.Forms's own portable Control - see its
+      constructor/SystemFonts usage.
+    -->
+
     <Copy SourceFiles="@(_ProGpuWpfPortableWinFormsCompatRuntimeAsset)"
           DestinationFiles="@(_ProGpuWpfPortableWinFormsCompatRuntimeAsset->'$(TargetDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
           SkipUnchangedFiles="false"

--- a/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.targets
+++ b/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.targets
@@ -21,6 +21,9 @@
     <ProGpuWpfSystemWindowsExtensionsVersion Condition="'$(ProGpuWpfSystemWindowsExtensionsVersion)' == ''">11.0.0-preview.5.26302.115</ProGpuWpfSystemWindowsExtensionsVersion>
     <ProGpuWpfClearMutablePackageOutputs Condition="'$(ProGpuWpfClearMutablePackageOutputs)' == '' And ('$([System.String]::Copy(`$(ProGpuWpfPackageVersion)`).Contains(`-dev`))' == 'True' Or '$([System.String]::Copy(`$(ProGpuWpfPackageVersion)`).Contains(`-preview`))' == 'True' Or '$([System.String]::Copy(`$(ProGpuWpfManagedPackageVersion)`).Contains(`-dev`))' == 'True' Or '$([System.String]::Copy(`$(ProGpuWpfManagedPackageVersion)`).Contains(`-preview`))' == 'True' Or '$([System.String]::Copy(`$(ProGpuPackageVersion)`).Contains(`-dev`))' == 'True' Or '$([System.String]::Copy(`$(ProGpuPackageVersion)`).Contains(`-preview`))' == 'True')">true</ProGpuWpfClearMutablePackageOutputs>
     <ProGpuWpfClearMutablePackageOutputs Condition="'$(ProGpuWpfClearMutablePackageOutputs)' == ''">false</ProGpuWpfClearMutablePackageOutputs>
+    <!-- Applications that provide one shared runtime payload can disable the SDK's late,
+         per-project runtime recopy while retaining the normal MSBuild copy-local pipeline. -->
+    <ProGpuWpfCopyPackageRuntimeAssets Condition="'$(ProGpuWpfCopyPackageRuntimeAssets)' == ''">true</ProGpuWpfCopyPackageRuntimeAssets>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ManagePackageVersionsCentrally)' != 'true'">
@@ -304,7 +307,7 @@
   <Target Name="_ProGpuWpfSdkCopyPackageRuntimeAssets"
           DependsOnTargets="ResolveLockFileCopyLocalFiles"
           AfterTargets="CopyFilesToOutputDirectory"
-          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '@(RuntimeCopyLocalItems)' != ''">
+          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ProGpuWpfCopyPackageRuntimeAssets)' == 'true' And '@(RuntimeCopyLocalItems)' != ''">
     <Copy SourceFiles="@(RuntimeCopyLocalItems)"
           DestinationFiles="@(RuntimeCopyLocalItems->'$(TargetDir)%(DestinationSubDirectory)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true" />
@@ -373,7 +376,7 @@
           DependsOnTargets="ResolveLockFileCopyLocalFiles;ResolveAssemblyReferences"
           AfterTargets="CopyFilesToOutputDirectory"
           BeforeTargets="_ProGpuWpfSdkCopyPackageRuntimeAssets"
-          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ProGpuWpfReferenceMode)' == 'Package'">
+          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ProGpuWpfCopyPackageRuntimeAssets)' == 'true' And '$(ProGpuWpfReferenceMode)' == 'Package'">
     <ItemGroup>
       <_ProGpuWpfManagedTransportReferenceAnchor
         Include="@(ReferencePath)"
@@ -432,7 +435,7 @@
   <Target Name="_ProGpuWpfSdkCopyPortableWinFormsCompatRuntimeAssets"
           DependsOnTargets="ResolveLockFileCopyLocalFiles"
           AfterTargets="_ProGpuWpfSdkCopyPackageRuntimeAssets"
-          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ProGpuWpfUsePortableWinFormsCompat)' == 'true'">
+          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ProGpuWpfCopyPackageRuntimeAssets)' == 'true' And '$(ProGpuWpfUsePortableWinFormsCompat)' == 'true'">
     <PropertyGroup>
       <_ProGpuWpfNuGetPackagesEnvironment>$([System.Environment]::GetEnvironmentVariable('NUGET_PACKAGES'))</_ProGpuWpfNuGetPackagesEnvironment>
       <_ProGpuWpfPackageRoot Condition="'$(NuGetPackageRoot)' != ''">$([MSBuild]::EnsureTrailingSlash('$(NuGetPackageRoot)'))</_ProGpuWpfPackageRoot>

--- a/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.targets
+++ b/packaging/ProGPU.Wpf.Sdk/targets/ProGPU.Wpf.Sdk.targets
@@ -31,12 +31,12 @@
     <PackageReference Include="Silk.NET.Windowing" Version="$(ProGpuWpfSilkNetVersion)" />
     <PackageReference Include="Silk.NET.WebGPU" Version="$(ProGpuWpfSilkNetVersion)" />
     <PackageReference Include="Silk.NET.WebGPU.Native.WGPU" Version="$(ProGpuWpfSilkNetVersion)" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ProGpuWpfSystemConfigurationConfigurationManagerVersion)" />
-    <PackageReference Include="System.Formats.Nrbf" Version="$(ProGpuWpfSystemFormatsNrbfVersion)" />
-    <PackageReference Include="System.IO.Packaging" Version="$(ProGpuWpfSystemIOPackagingVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(ProGpuWpfSystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Include="System.Security.Permissions" Version="$(ProGpuWpfSystemSecurityPermissionsVersion)" />
-    <PackageReference Include="System.Windows.Extensions" Version="$(ProGpuWpfSystemWindowsExtensionsVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ProGpuWpfSystemConfigurationConfigurationManagerVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Formats.Nrbf" Version="$(ProGpuWpfSystemFormatsNrbfVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Packaging" Version="$(ProGpuWpfSystemIOPackagingVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(ProGpuWpfSystemSecurityCryptographyXmlVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Security.Permissions" Version="$(ProGpuWpfSystemSecurityPermissionsVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Windows.Extensions" Version="$(ProGpuWpfSystemWindowsExtensionsVersion)" GeneratePathProperty="true" />
     <PackageReference Include="OpenFontSharp" Version="$(ProGpuWpfOpenFontSharpVersion)" />
     <PackageReference Include="StbImageSharp" Version="$(ProGpuWpfStbImageSharpVersion)" />
   </ItemGroup>
@@ -46,12 +46,12 @@
     <PackageReference Include="Silk.NET.Windowing" VersionOverride="$(ProGpuWpfSilkNetVersion)" />
     <PackageReference Include="Silk.NET.WebGPU" VersionOverride="$(ProGpuWpfSilkNetVersion)" />
     <PackageReference Include="Silk.NET.WebGPU.Native.WGPU" VersionOverride="$(ProGpuWpfSilkNetVersion)" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" VersionOverride="$(ProGpuWpfSystemConfigurationConfigurationManagerVersion)" />
-    <PackageReference Include="System.Formats.Nrbf" VersionOverride="$(ProGpuWpfSystemFormatsNrbfVersion)" />
-    <PackageReference Include="System.IO.Packaging" VersionOverride="$(ProGpuWpfSystemIOPackagingVersion)" />
-    <PackageReference Include="System.Security.Cryptography.Xml" VersionOverride="$(ProGpuWpfSystemSecurityCryptographyXmlVersion)" />
-    <PackageReference Include="System.Security.Permissions" VersionOverride="$(ProGpuWpfSystemSecurityPermissionsVersion)" />
-    <PackageReference Include="System.Windows.Extensions" VersionOverride="$(ProGpuWpfSystemWindowsExtensionsVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" VersionOverride="$(ProGpuWpfSystemConfigurationConfigurationManagerVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Formats.Nrbf" VersionOverride="$(ProGpuWpfSystemFormatsNrbfVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.IO.Packaging" VersionOverride="$(ProGpuWpfSystemIOPackagingVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Security.Cryptography.Xml" VersionOverride="$(ProGpuWpfSystemSecurityCryptographyXmlVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Security.Permissions" VersionOverride="$(ProGpuWpfSystemSecurityPermissionsVersion)" GeneratePathProperty="true" />
+    <PackageReference Include="System.Windows.Extensions" VersionOverride="$(ProGpuWpfSystemWindowsExtensionsVersion)" GeneratePathProperty="true" />
     <PackageReference Include="OpenFontSharp" VersionOverride="$(ProGpuWpfOpenFontSharpVersion)" />
     <PackageReference Include="StbImageSharp" VersionOverride="$(ProGpuWpfStbImageSharpVersion)" />
   </ItemGroup>
@@ -72,6 +72,39 @@
       <TransitiveFrameworkReference
         Remove="@(TransitiveFrameworkReference)"
         Condition="'%(TransitiveFrameworkReference.Identity)' == 'Microsoft.WindowsDesktop.App' Or '%(TransitiveFrameworkReference.Identity)' == 'Microsoft.WindowsDesktop.App.WPF'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ProGpuWpfSdkRemoveWindowsDesktopSupportFacades"
+          BeforeTargets="ResolveAssemblyReferences"
+          DependsOnTargets="ResolveLockFileReferences"
+          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true'">
+    <ItemGroup>
+      <Reference
+        Remove="@(Reference)"
+        Condition="('%(Reference.Filename)' == 'System.Configuration.ConfigurationManager' Or '%(Reference.Filename)' == 'System.Formats.Nrbf' Or '%(Reference.Filename)' == 'System.IO.Packaging' Or '%(Reference.Filename)' == 'System.Security.Cryptography.Xml' Or '%(Reference.Filename)' == 'System.Security.Permissions' Or '%(Reference.Filename)' == 'System.Windows.Extensions') And $([System.String]::Copy('%(Reference.FrameworkReferenceName)').StartsWith('Microsoft.WindowsDesktop.App'))" />
+      <Reference Include="$(PkgSystem_Configuration_ConfigurationManager)/lib/net10.0/System.Configuration.ConfigurationManager.dll" Private="true" Condition="Exists('$(PkgSystem_Configuration_ConfigurationManager)/lib/net10.0/System.Configuration.ConfigurationManager.dll')" />
+      <Reference Include="$(PkgSystem_Formats_Nrbf)/lib/net10.0/System.Formats.Nrbf.dll" Private="true" Condition="Exists('$(PkgSystem_Formats_Nrbf)/lib/net10.0/System.Formats.Nrbf.dll')" />
+      <Reference Include="$(PkgSystem_IO_Packaging)/lib/net10.0/System.IO.Packaging.dll" Private="true" Condition="Exists('$(PkgSystem_IO_Packaging)/lib/net10.0/System.IO.Packaging.dll')" />
+      <Reference Include="$(PkgSystem_Security_Cryptography_Xml)/lib/net10.0/System.Security.Cryptography.Xml.dll" Private="true" Condition="Exists('$(PkgSystem_Security_Cryptography_Xml)/lib/net10.0/System.Security.Cryptography.Xml.dll')" />
+      <Reference Include="$(PkgSystem_Security_Permissions)/lib/net10.0/System.Security.Permissions.dll" Private="true" Condition="Exists('$(PkgSystem_Security_Permissions)/lib/net10.0/System.Security.Permissions.dll')" />
+      <Reference Include="$(PkgSystem_Windows_Extensions)/lib/net10.0/System.Windows.Extensions.dll" Private="true" Condition="Exists('$(PkgSystem_Windows_Extensions)/lib/net10.0/System.Windows.Extensions.dll')" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ProGpuWpfSdkPreferTransportReferences"
+          BeforeTargets="ResolveAssemblyReferences"
+          DependsOnTargets="ResolveLockFileReferences"
+          Condition="'$(ProGpuWpfUsePortableFrameworkReferences)' == 'true' And '$(ProGpuWpfReferenceMode)' == 'Package' And '$(PkgLibreWPF_Transport)' != ''">
+    <ItemGroup>
+      <_ProGpuWpfTransportReference Include="$(PkgLibreWPF_Transport)/ref/net10.0/*.dll" />
+      <Reference Remove="@(_ProGpuWpfTransportReference)"
+                 MatchOnMetadata="Filename"
+                 MatchOnMetadataOptions="CaseInsensitive" />
+      <Reference Include="@(_ProGpuWpfTransportReference)" Private="true" />
+      <Reference Include="$(PkgLibreWPF_Transport)/lib/net10.0/System.Private.Windows.Core.dll"
+                 Private="true"
+                 Condition="Exists('$(PkgLibreWPF_Transport)/lib/net10.0/System.Private.Windows.Core.dll')" />
     </ItemGroup>
   </Target>
 
@@ -356,9 +389,11 @@
       <_ProGpuWpfManagedTransportDependencyRuntimeAsset
         Include="$(_ProGpuWpfManagedTransportRuntimeRoot)*.dll"
         Exclude="$(_ProGpuWpfManagedTransportRuntimeRoot)PresentationCore.dll" />
+      <RuntimeCopyLocalItems Remove="@(_ProGpuWpfManagedTransportDependencyRuntimeAsset)"
+                             MatchOnMetadata="Filename"
+                             MatchOnMetadataOptions="CaseInsensitive" />
       <RuntimeCopyLocalItems
-        Include="@(_ProGpuWpfManagedTransportDependencyRuntimeAsset)"
-        Exclude="@(RuntimeCopyLocalItems)">
+        Include="@(_ProGpuWpfManagedTransportDependencyRuntimeAsset)">
         <NuGetPackageId>$(ProGpuWpfManagedPackageId)</NuGetPackageId>
         <NuGetPackageVersion>$(ProGpuWpfManagedPackageVersion)</NuGetPackageVersion>
         <AssetType>runtime</AssetType>

--- a/src/ProGPU.Wpf.SdkExternalSmokeHarness/Program.cs
+++ b/src/ProGPU.Wpf.SdkExternalSmokeHarness/Program.cs
@@ -312,8 +312,8 @@ internal static class Program
         AssertContains(portableProps, "<Page Include=\"**/*.xaml\"", "SDK default page XAML item");
         AssertContains(portableTargets, "<PackageReference Include=\"Silk.NET.WebGPU.Native.WGPU\" Version=\"$(ProGpuWpfSilkNetVersion)\" />", "SDK native WebGPU package reference");
         AssertContains(portableTargets, "<PackageReference Include=\"Silk.NET.WebGPU.Native.WGPU\" VersionOverride=\"$(ProGpuWpfSilkNetVersion)\" />", "SDK CPM native WebGPU package reference");
-        AssertContains(portableTargets, "<PackageReference Include=\"System.IO.Packaging\" Version=\"$(ProGpuWpfSystemIOPackagingVersion)\" />", "SDK WPF support package reference");
-        AssertContains(portableTargets, "<PackageReference Include=\"System.IO.Packaging\" VersionOverride=\"$(ProGpuWpfSystemIOPackagingVersion)\" />", "SDK CPM WPF support package reference");
+        AssertContains(portableTargets, "<PackageReference Include=\"System.IO.Packaging\" Version=\"$(ProGpuWpfSystemIOPackagingVersion)\" GeneratePathProperty=\"true\" />", "SDK WPF support package reference");
+        AssertContains(portableTargets, "<PackageReference Include=\"System.IO.Packaging\" VersionOverride=\"$(ProGpuWpfSystemIOPackagingVersion)\" GeneratePathProperty=\"true\" />", "SDK CPM WPF support package reference");
         AssertContains(portableTargets, "<PackageReference Include=\"OpenFontSharp\" Version=\"$(ProGpuWpfOpenFontSharpVersion)\" />", "SDK OpenFontSharp package reference");
         AssertContains(portableTargets, "<PackageReference Include=\"OpenFontSharp\" VersionOverride=\"$(ProGpuWpfOpenFontSharpVersion)\" />", "SDK CPM OpenFontSharp package reference");
         AssertContains(portableTargets, "<PackageReference Include=\"StbImageSharp\" Version=\"$(ProGpuWpfStbImageSharpVersion)\" />", "SDK StbImageSharp package reference");
@@ -351,6 +351,7 @@ internal static class Program
         AssertContains(portableTargets, "librewpf.transport/$(ProGpuWpfManagedPackageVersion)/lib/$(_ProGpuWpfManagedTransportRuntimeTfm)/", "SDK managed transport package root");
         AssertContains(portableTargets, "'$(RestorePackagesPath)' != ''", "SDK isolated managed transport restore root");
         AssertContains(portableTargets, "_ProGpuWpfSdkCopyPackageRuntimeAssets", "SDK managed runtime copy target");
+        AssertContains(portableTargets, "_ProGpuWpfSdkRemoveWindowsDesktopSupportFacades", "SDK support-package facade removal target");
         AssertContains(portableTargets, "_ProGpuWpfSdkCopyNativeRuntimeAssets", "SDK native runtime copy target");
 
         AssertContains(

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -14524,19 +14524,19 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("<PackageReference Include=\"Silk.NET.Windowing\" Version=\"$(ProGpuWpfSilkNetVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"Silk.NET.WebGPU\" Version=\"$(ProGpuWpfSilkNetVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"Silk.NET.WebGPU.Native.WGPU\" Version=\"$(ProGpuWpfSilkNetVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Configuration.ConfigurationManager\" Version=\"$(ProGpuWpfSystemConfigurationConfigurationManagerVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Formats.Nrbf\" Version=\"$(ProGpuWpfSystemFormatsNrbfVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.IO.Packaging\" Version=\"$(ProGpuWpfSystemIOPackagingVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Security.Cryptography.Xml\" Version=\"$(ProGpuWpfSystemSecurityCryptographyXmlVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Security.Permissions\" Version=\"$(ProGpuWpfSystemSecurityPermissionsVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Windows.Extensions\" Version=\"$(ProGpuWpfSystemWindowsExtensionsVersion)\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Configuration.ConfigurationManager\" Version=\"$(ProGpuWpfSystemConfigurationConfigurationManagerVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Formats.Nrbf\" Version=\"$(ProGpuWpfSystemFormatsNrbfVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.IO.Packaging\" Version=\"$(ProGpuWpfSystemIOPackagingVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Security.Cryptography.Xml\" Version=\"$(ProGpuWpfSystemSecurityCryptographyXmlVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Security.Permissions\" Version=\"$(ProGpuWpfSystemSecurityPermissionsVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Windows.Extensions\" Version=\"$(ProGpuWpfSystemWindowsExtensionsVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"OpenFontSharp\" Version=\"$(ProGpuWpfOpenFontSharpVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"StbImageSharp\" Version=\"$(ProGpuWpfStbImageSharpVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"Silk.NET.Input\" VersionOverride=\"$(ProGpuWpfSilkNetVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"Silk.NET.WebGPU.Native.WGPU\" VersionOverride=\"$(ProGpuWpfSilkNetVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.IO.Packaging\" VersionOverride=\"$(ProGpuWpfSystemIOPackagingVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Security.Cryptography.Xml\" VersionOverride=\"$(ProGpuWpfSystemSecurityCryptographyXmlVersion)\" />", portableTargets, StringComparison.Ordinal);
-        Assert.Contains("<PackageReference Include=\"System.Security.Permissions\" VersionOverride=\"$(ProGpuWpfSystemSecurityPermissionsVersion)\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.IO.Packaging\" VersionOverride=\"$(ProGpuWpfSystemIOPackagingVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Security.Cryptography.Xml\" VersionOverride=\"$(ProGpuWpfSystemSecurityCryptographyXmlVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"System.Security.Permissions\" VersionOverride=\"$(ProGpuWpfSystemSecurityPermissionsVersion)\" GeneratePathProperty=\"true\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"OpenFontSharp\" VersionOverride=\"$(ProGpuWpfOpenFontSharpVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.Contains("<PackageReference Include=\"StbImageSharp\" VersionOverride=\"$(ProGpuWpfStbImageSharpVersion)\" />", portableTargets, StringComparison.Ordinal);
         Assert.DoesNotContain("<PackageReference Include=\"Microsoft.Win32.SystemEvents\"", portableTargets, StringComparison.Ordinal);
@@ -14653,6 +14653,7 @@ public sealed class WpfManagedProjectGraphTests
                 < portableTargets.IndexOf("'$(NuGetPackageRoot)' != ''", StringComparison.Ordinal),
             "The managed transport copy must prefer the active isolated restore root over the global NuGet package root.");
         Assert.Contains("_ProGpuWpfSdkCopyPackageRuntimeAssets", portableTargets, StringComparison.Ordinal);
+        Assert.Contains("_ProGpuWpfSdkRemoveWindowsDesktopSupportFacades", portableTargets, StringComparison.Ordinal);
         Assert.Contains("_ProGpuWpfSdkCopyNativeRuntimeAssets", portableTargets, StringComparison.Ordinal);
         Assert.Contains("DependsOnTargets=\"ResolveLockFileCopyLocalFiles\"", portableTargets, StringComparison.Ordinal);
         Assert.Contains("DependsOnTargets=\"ResolvePackageAssets\"", portableTargets, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

Three packaging-level improvements for downstream hosts that manage one shared runtime payload:

1. **`ProGpuWpfCopyPackageRuntimeAssets`** (default `true`) — applications that provide one shared runtime payload can disable the SDK's late, per-project runtime recopy while retaining the normal MSBuild copy-local pipeline.
2. **`GeneratePathProperty=true`** on the six support PackageReferences so consumers can resolve package paths for native interop shims.
3. **Win32 compat shim exports** (`GetSystemDefaultLCID`, `GetUserDefaultLCID`, `GetThreadLocale`, `*DefaultLangID`, `GetObject*`) in `ProGPU.Wpf.Sdk.Win32Compat.c`: a fixed en-US LCID is sufficient because callers only special-case Arabic/Japanese before falling through to locale-independent selection; `GetObject*` return 0 (real Win32 failure) so callers' own fallback paths run instead of pretending to fill an output struct.

## Tests

- `WpfManagedProjectGraphTests.ProGpuWpfSdkProvidesSwitchOnlyPackagingSurface` updated for all three (96 assertions pass against this tree).
- SDK switch/mixed/external smokes verified green downstream.

Note: items in (3) overlap with the portability question raised in wieslawsoltes/LibreWinForms#26 — happy to drop the shim exports if a managed-side fix lands there first.