### PR TITLE
[WIP] Assorted portable fixes: mouse-up routing, designer exceptions, handle exposure, custom chrome, image rendering, screenshot

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Interop/HwndHost.cs
@@ -65,7 +65,9 @@ namespace System.Windows.Interop
         {
             get
             {
-                if (_hwnd.Handle != IntPtr.Zero)
+                // _hwnd is never a real Win32 HWND on non-Windows platforms (see BuildWindowCore
+                // overrides that return a sentinel there instead), so there is no IsWindow to ask.
+                if (global::System.OperatingSystem.IsWindows() && _hwnd.Handle != IntPtr.Zero)
                 {
                     if (!UnsafeNativeMethods.IsWindow(_hwnd))
                     {
@@ -1090,17 +1092,31 @@ namespace System.Windows.Interop
             // Assume the desired size is the initial size.  If the window was
             // created with a 0-length dimension, we assume this means we
             // should fill all available space.
-            NativeMethods.RECT rc = new NativeMethods.RECT();
-            SafeNativeMethods.GetWindowRect(_hwnd, ref rc);
+            //
+            // There is no real child HWND on non-Windows platforms (see BuildWindowCore
+            // overrides that return a sentinel handle there), so there is nothing for
+            // GetWindowRect to report on - default to zero, same as an actual 0-length
+            // window would produce. Subclasses that need a real size on this platform
+            // (e.g. AvalonDock's LayoutAutoHideWindowControl) already override
+            // MeasureOverride/ArrangeOverride themselves rather than relying on this.
+            if (global::System.OperatingSystem.IsWindows())
+            {
+                NativeMethods.RECT rc = new NativeMethods.RECT();
+                SafeNativeMethods.GetWindowRect(_hwnd, ref rc);
 
-            // Convert from pixels to measure units.
-            // PresentationSource can't be null if we get here.
-            PresentationSource source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */);
-            Point ptUpperLeft = new Point(rc.left, rc.top);
-            Point ptLowerRight = new Point(rc.right, rc.bottom);
-            ptUpperLeft = source.CompositionTarget.TransformFromDevice.Transform(ptUpperLeft);
-            ptLowerRight = source.CompositionTarget.TransformFromDevice.Transform(ptLowerRight);
-            _desiredSize = new Size(ptLowerRight.X - ptUpperLeft.X, ptLowerRight.Y - ptUpperLeft.Y);
+                // Convert from pixels to measure units.
+                // PresentationSource can't be null if we get here.
+                PresentationSource source = PresentationSource.CriticalFromVisual(this, false /* enable2DTo3DTransition */);
+                Point ptUpperLeft = new Point(rc.left, rc.top);
+                Point ptLowerRight = new Point(rc.right, rc.bottom);
+                ptUpperLeft = source.CompositionTarget.TransformFromDevice.Transform(ptUpperLeft);
+                ptLowerRight = source.CompositionTarget.TransformFromDevice.Transform(ptLowerRight);
+                _desiredSize = new Size(ptLowerRight.X - ptUpperLeft.X, ptLowerRight.Y - ptUpperLeft.Y);
+            }
+            else
+            {
+                _desiredSize = new Size(0, 0);
+            }
 
             // We have a new desired size, so invalidate measure.
             InvalidateMeasure();

--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Window.cs
@@ -7425,6 +7425,24 @@ namespace System.Windows
 
             _portableWindowActivation = activation;
             SetIWindowService();
+
+            // WindowChrome (via the WindowChromeWorker attached property, applied through a Style
+            // Setter) can call SetPortableCustomChrome before this window's portable activation
+            // exists yet - template/Style application on first layout can race ahead of Show()'s own
+            // TryActivate call above. SetPortableCustomChrome's null-activation guard silently skips
+            // the SetWindowBorder call in that case, and because the method also short-circuits on an
+            // unchanged _hasPortableCustomChrome value, that skipped call is never retried later - the
+            // window is left with its native chrome/title bar showing even though custom chrome (e.g.
+            // AvalonDock's floating window caption) was requested. Now that activation exists, sync
+            // the border state for real if custom chrome was already requested.
+            if (_hasPortableCustomChrome)
+            {
+                PortableWindowActivationService.SetWindowBorder(
+                    _portableWindowActivation,
+                    ResizeMode,
+                    GetPortableWindowStyle());
+            }
+
             OnSourceInitialized(EventArgs.Empty);
             return true;
         }

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/HwndSubclass.cs
@@ -36,11 +36,21 @@ namespace MS.Win32
         {
             DetachMessage = UnsafeNativeMethods.RegisterWindowMessage("HwndSubclass.DetachMessage");
 
-            // Go find the address of DefWindowProc.
-            IntPtr hModuleUser32 = UnsafeNativeMethods.GetModuleHandle(ExternDll.User32);
-            IntPtr address = UnsafeNativeMethods.GetProcAddress(new HandleRef(null,hModuleUser32), "DefWindowProcW");
+            // Go find the address of DefWindowProc. There is no real user32.dll/kernel32.dll on
+            // non-Windows platforms, so there is no such address to resolve - DefWndProc is only
+            // ever consulted as a fallback default window procedure for a real native HWND
+            // message loop, which the portable host doesn't run.
+            if (OperatingSystem.IsWindows())
+            {
+                IntPtr hModuleUser32 = UnsafeNativeMethods.GetModuleHandle(ExternDll.User32);
+                IntPtr address = UnsafeNativeMethods.GetProcAddress(new HandleRef(null,hModuleUser32), "DefWindowProcW");
 
-            DefWndProc = address;
+                DefWndProc = address;
+            }
+            else
+            {
+                DefWndProc = IntPtr.Zero;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/SafeNativeMethodsCLR.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using MS.Utility;
 
 namespace MS.Win32
@@ -148,9 +149,66 @@ namespace MS.Win32
 
         public static int GetDoubleClickTime()
         {
-            return System.OperatingSystem.IsWindows()
-                ? SafeNativeMethodsPrivate.GetDoubleClickTime()
-                : 500;
+            if (System.OperatingSystem.IsWindows())
+            {
+                return SafeNativeMethodsPrivate.GetDoubleClickTime();
+            }
+
+            if (System.OperatingSystem.IsMacOS())
+            {
+                return SafeNativeMethodsMac.GetDoubleClickTimeMilliseconds();
+            }
+
+            return 500;
+        }
+
+        [SupportedOSPlatform("macos")]
+        private static class SafeNativeMethodsMac
+        {
+            private const string ObjCLibrary = "/usr/lib/libobjc.A.dylib";
+            private const int DefaultDoubleClickMilliseconds = 500;
+
+            public static int GetDoubleClickTimeMilliseconds()
+            {
+                try
+                {
+                    IntPtr nsEventClass = ObjCGetClass("NSEvent");
+                    IntPtr doubleClickIntervalSelector = SelRegisterName("doubleClickInterval");
+                    if (nsEventClass == IntPtr.Zero || doubleClickIntervalSelector == IntPtr.Zero)
+                    {
+                        return DefaultDoubleClickMilliseconds;
+                    }
+
+                    // objc_msgSend returning a double requires the fpret entry point on x86_64
+                    // (the classic ABI returns floating-point values via XMM0, not RAX), while
+                    // arm64 uses the ordinary entry point for all return types.
+                    double seconds = RuntimeInformation.ProcessArchitecture == Architecture.X64
+                        ? ObjCMsgSendFpretReturningDouble(nsEventClass, doubleClickIntervalSelector)
+                        : ObjCMsgSendReturningDouble(nsEventClass, doubleClickIntervalSelector);
+
+                    return seconds > 0 ? (int)Math.Round(seconds * 1000) : DefaultDoubleClickMilliseconds;
+                }
+                catch (DllNotFoundException)
+                {
+                    return DefaultDoubleClickMilliseconds;
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    return DefaultDoubleClickMilliseconds;
+                }
+            }
+
+            [DllImport(ObjCLibrary, EntryPoint = "objc_getClass")]
+            private static extern IntPtr ObjCGetClass([MarshalAs(UnmanagedType.LPStr)] string name);
+
+            [DllImport(ObjCLibrary, EntryPoint = "sel_registerName")]
+            private static extern IntPtr SelRegisterName([MarshalAs(UnmanagedType.LPStr)] string name);
+
+            [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+            private static extern double ObjCMsgSendReturningDouble(IntPtr receiver, IntPtr selector);
+
+            [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend_fpret")]
+            private static extern double ObjCMsgSendFpretReturningDouble(IntPtr receiver, IntPtr selector);
         }
 
         public static bool IsWindowEnabled(HandleRef hWnd)

--- a/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/MS/Win32/UnsafeNativeMethodsCLR.cs
@@ -46,8 +46,25 @@ namespace MS.Win32
         public static extern int GetCurrentThemeName(StringBuilder pszThemeFileName, int dwMaxNameChars, StringBuilder pszColorBuff, int dwMaxColorChars, StringBuilder pszSizeBuff, int cchMaxSizeChars);
 
 #if !DRT && !UIAUTOMATIONTYPES
-        [DllImport(ExternDll.User32, CharSet = CharSet.Auto, BestFitMapping = false)]
-        public static extern WindowMessage RegisterWindowMessage(string msg);
+        // Real Win32 RegisterWindowMessage() returns a process-wide unique atom in the
+        // 0xC000-0xFFFF range. Callers here (HwndWrapper, HwndSubclass) only use the
+        // returned value as an opaque private token to tag/compare messages within their
+        // own message loop - it never needs to be a real registered Win32 atom. On
+        // non-Windows platforms there is no user32.dll to call into, so synthesize a
+        // unique token from the same reserved range instead of P/Invoking.
+        private static int s_syntheticWindowMessage = unchecked((int)0xC000);
+
+        public static WindowMessage RegisterWindowMessage(string msg)
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                return (WindowMessage)System.Threading.Interlocked.Increment(ref s_syntheticWindowMessage);
+            }
+            return Win32RegisterWindowMessage(msg);
+        }
+
+        [DllImport(ExternDll.User32, CharSet = CharSet.Auto, BestFitMapping = false, EntryPoint = "RegisterWindowMessage")]
+        private static extern WindowMessage Win32RegisterWindowMessage(string msg);
 #endif
 
         [DllImport(ExternDll.User32, EntryPoint = "SetWindowPos", ExactSpelling = true, CharSet = CharSet.Auto, SetLastError = true)]

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19280,6 +19280,67 @@ public sealed class WpfManagedProjectGraphTests
             item => string.Equals(item.Attribute("Include")?.Value, include, StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void PortableMiscFixesKeepDesignerWorkloadsAlive()
+    {
+        // Synthetic input can deliver a mouse-up without a matching down (the injected
+        // down may be dropped while the window activates). Skipping the up left
+        // Mouse.LeftButton stuck Pressed for the app lifetime; forward it verbatim.
+        var inputService = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "Platform",
+            "SilkNetWpfInputService.cs"));
+        Assert.Contains("pressedButtons.Remove(button);", inputService, StringComparison.Ordinal);
+        Assert.DoesNotContain("if (!pressedButtons.Remove(button))\n                {\n                    return;", inputService, StringComparison.Ordinal);
+
+        // Input callbacks that throw must marshal to the window dispatcher instead of
+        // tearing down the native loop - mirrors what the Framework designer surface did.
+        var activationService = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "WpfPortableWindowActivation.cs"));
+        Assert.Contains("private bool TryReportInputExceptionToWindowDispatcher(Exception exception)", activationService, StringComparison.Ordinal);
+
+        // Expose the genuine OS window handle (NSWindow*/HWND/X11 Window) for interop -
+        // the compat-shim Handle is synthetic and never a real platform handle.
+        var presentationSourceBridge = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "WpfPortablePresentationSourceBridge.cs"));
+        Assert.Contains("public bool TryGetNativeHandle(out IntPtr handle)", presentationSourceBridge, StringComparison.Ordinal);
+
+        // Custom chrome applied via Style Setter races ahead of Show()'s activate; sync
+        // border state once activation exists or the native title bar stays visible.
+        var window = File.ReadAllText(FindRepoPath(
+            "src",
+            "Microsoft.DotNet.Wpf",
+            "src",
+            "PresentationFramework",
+            "System",
+            "Windows",
+            "Window.cs"));
+        var chromeSync = "if (_hasPortableCustomChrome)\n            {\n                PortableWindowActivationService.SetWindowBorder(";
+        Assert.Contains(chromeSync, window, StringComparison.Ordinal);
+
+        // Adapted pen thickness must leave local space to match ProGPU render-command
+        // contract, or images/geometry stroked with adapted pens repaint incorrectly.
+        var compositionCommandSink = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "Composition",
+            "ProGpuCompositionCommandSink.cs"));
+        Assert.Contains("private VectorPen? ScalePenThicknessToDeviceSpace(VectorPen? pen)", compositionCommandSink, StringComparison.Ordinal);
+
+        // CopyFromScreen has no portable implementation; read the compositor backbuffer
+        // and encode PNG for cross-platform screenshots instead.
+        var screenshot = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "ProGpuWpfScreenshot.cs"));
+        Assert.Contains("public static byte[]? TryCapturePng(object window)", screenshot, StringComparison.Ordinal);
+    }
+
     private static void AssertGuardBefore(string source, string guard, string guardedCall)
     {
         var guardIndex = source.IndexOf(guard, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -9195,7 +9195,9 @@ public sealed class WpfManagedProjectGraphTests
         AssertGuardBefore(safeNativeMethodsOther, "if (!OperatingSystem.IsWindows())", "SafeNativeMethodsPrivate.GetCaretBlinkTime()");
         AssertGuardBefore(safeNativeMethodsClr, "if (!OperatingSystem.IsWindows())", "SafeNativeMethodsPrivate.GetTickCount()");
         Assert.Contains("return Environment.TickCount;", safeNativeMethodsClr, StringComparison.Ordinal);
-        Assert.Contains("return System.OperatingSystem.IsWindows()\n                ? SafeNativeMethodsPrivate.GetDoubleClickTime()\n                : 500;", safeNativeMethodsClr, StringComparison.Ordinal);
+        Assert.Contains("if (System.OperatingSystem.IsWindows())\n            {\n                return SafeNativeMethodsPrivate.GetDoubleClickTime();\n            }", safeNativeMethodsClr, StringComparison.Ordinal);
+        Assert.Contains("if (System.OperatingSystem.IsMacOS())\n            {\n                return SafeNativeMethodsMac.GetDoubleClickTimeMilliseconds();\n            }", safeNativeMethodsClr, StringComparison.Ordinal);
+        Assert.Contains("[DllImport(ObjCLibrary, EntryPoint = \"objc_msgSend_fpret\")]", safeNativeMethodsClr, StringComparison.Ordinal);
         Assert.Contains("return IntGetParent(hWnd);", unsafeNativeMethodsClr, StringComparison.Ordinal);
         Assert.Contains("[DllImport(ExternDll.User32, EntryPoint = \"GetParent\"", unsafeNativeMethodsClr, StringComparison.Ordinal);
         AssertGuardBefore(hwndHost, "if (!global::System.OperatingSystem.IsWindows())", "UnsafeNativeMethods.GetParent(_hwnd)");

--- a/src/ProGPU.Wpf/Composition/ProGpuCompositionCommandSink.cs
+++ b/src/ProGPU.Wpf/Composition/ProGpuCompositionCommandSink.cs
@@ -1440,7 +1440,48 @@ public sealed class ProGpuCompositionCommandSink :
 
         var nativePen = WpfResourceResolver.AdaptNativePen(pen, bounds, out var unsupportedStateCount);
         UnsupportedStateCount += unsupportedStateCount;
-        return nativePen;
+        return ScalePenThicknessToDeviceSpace(nativePen);
+    }
+
+    /// <summary>
+    /// Converts an adapted pen's thickness out of local space, matching the contract ProGPU's
+    /// render commands are built on.
+    /// </summary>
+    /// <remarks>
+    /// A render command carries its geometry in local space plus a Transform, but its
+    /// Pen.Thickness is expected to already be in device space: the compositor transforms the
+    /// geometry and then expands the stroke by the thickness verbatim (Compositor.CompileLineCommand),
+    /// and divides the stroke scale back out on the few paths that need local units. ProGPU's own
+    /// WPF DrawingContext upholds this by multiplying by the current stroke scale before emitting a
+    /// command. This sink did not, so every stroke under a scaling transform kept its unscaled
+    /// width - most visibly, a Border with a non-uniform BorderThickness inside a Viewbox filled
+    /// solid once its edges grew wider than the shrunken box. The adapted pen can be a shared
+    /// cached instance, so return a copy instead of mutating it.
+    /// </remarks>
+    private VectorPen? ScalePenThicknessToDeviceSpace(VectorPen? pen)
+    {
+        if (pen == null)
+        {
+            return null;
+        }
+
+        var strokeScale = global::ProGPU.Vector.TransformMetrics.GetStrokeScale(_transformStack.Peek());
+        if (!float.IsFinite(strokeScale) || strokeScale <= 0f ||
+            Math.Abs(strokeScale - 1f) <= TransformEpsilon)
+        {
+            return pen;
+        }
+
+        return new VectorPen(
+            pen.Brush,
+            pen.Thickness * strokeScale,
+            pen.LineJoin,
+            pen.MiterLimit,
+            pen.StartLineCap,
+            pen.EndLineCap,
+            pen.DashCap,
+            pen.DashArray,
+            pen.DashOffset);
     }
 
     private VectorBrush? ToNativeGlyphRunBrush(MediaBrush foregroundBrush, in WpfNativeGlyphRun glyphRun)

--- a/src/ProGPU.Wpf/Platform/SilkNetWpfInputService.cs
+++ b/src/ProGPU.Wpf/Platform/SilkNetWpfInputService.cs
@@ -127,11 +127,14 @@ public sealed class SilkNetWpfInputService : IWpfInputService, ISilkNetWpfInputC
             };
             Action<SilkInput.IMouse, SilkInput.MouseButton> mouseUp = (_, button) =>
             {
-                if (!pressedButtons.Remove(button))
-                {
-                    return;
-                }
-
+                // The down/up sequence must be forwarded verbatim: synthetic input (OS-level
+                // automation such as cliclick) can deliver a mouse-up without a matching down (the
+                // injected down may have been dropped while the window was being activated, or the
+                // press started before the input context was fully attached). Suppressing the up
+                // leaves WPF's Mouse.LeftButton stuck in the Pressed state for the rest of the app
+                // lifetime, which corrupts every later drag. Forward it unconditionally; WPF keeps
+                // its own button-state bookkeeping.
+                pressedButtons.Remove(button);
                 var position = ResolveMousePosition(mouse.Position, lastPosition, hasLastPosition);
                 if (IsFinite(position))
                 {

--- a/src/ProGPU.Wpf/ProGpuWpfScreenshot.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfScreenshot.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using ProGPU.Backend;
+using Silk.NET.WebGPU;
+
+namespace System.Windows.Media.ProGPU;
+
+public unsafe static class ProGpuWpfScreenshot
+{
+    public static byte[]? TryCapturePng(object window)
+    {
+        if (window == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            if (!WpfPortableWindowActivation.TryGetActiveHost(window, out ProGpuWpfWindowHost? host) ||
+                host?.CompositionTarget is not { } target ||
+                target.Context.Surface == null)
+            {
+                return null;
+            }
+
+            var geometry = host.ResolveCurrentRenderSurfaceGeometryForDiagnostics();
+            uint pixelWidth = Math.Max(1u, geometry.PixelWidth);
+            uint pixelHeight = Math.Max(1u, geometry.PixelHeight);
+
+            using var offscreenTexture = new GpuTexture(
+                target.Context,
+                pixelWidth,
+                pixelHeight,
+                target.Context.SwapChainFormat,
+                TextureUsage.RenderAttachment | TextureUsage.CopySrc,
+                "ProGpuWpfScreenshot Offscreen Target");
+
+            target.Render(
+                geometry.LogicalWidth,
+                geometry.LogicalHeight,
+                pixelWidth,
+                pixelHeight,
+                (float)geometry.DpiScale,
+                offscreenTexture.ViewPtr);
+
+            byte[] pixels = offscreenTexture.ReadPixels();
+            ConvertToRgbaInPlace(pixels, target.Context.SwapChainFormat);
+
+            return PngEncoder.Encode(pixels, pixelWidth, pixelHeight);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void ConvertToRgbaInPlace(byte[] pixels, TextureFormat format)
+    {
+        if (format is not (TextureFormat.Bgra8Unorm or TextureFormat.Bgra8UnormSrgb))
+        {
+            return;
+        }
+
+        for (int i = 0; i + 3 < pixels.Length; i += 4)
+        {
+            (pixels[i], pixels[i + 2]) = (pixels[i + 2], pixels[i]);
+        }
+    }
+
+    private static class PngEncoder
+    {
+        private static readonly uint[] CrcTable = BuildCrcTable();
+
+        public static byte[] Encode(byte[] rgbaPixels, uint width, uint height)
+        {
+            using var output = new MemoryStream();
+            output.Write(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, 0, 8);
+
+            byte[] ihdr = new byte[13];
+            WriteUInt32BigEndian(ihdr, 0, width);
+            WriteUInt32BigEndian(ihdr, 4, height);
+            ihdr[8] = 8;
+            ihdr[9] = 6;
+            ihdr[10] = 0;
+            ihdr[11] = 0;
+            ihdr[12] = 0;
+            WriteChunk(output, "IHDR", ihdr);
+
+            byte[] scanlines = new byte[height * (1 + width * 4)];
+            int srcIndex = 0;
+            int dstIndex = 0;
+            for (int y = 0; y < height; y++)
+            {
+                scanlines[dstIndex++] = 0;
+                Array.Copy(rgbaPixels, srcIndex, scanlines, dstIndex, (int)(width * 4));
+                srcIndex += (int)(width * 4);
+                dstIndex += (int)(width * 4);
+            }
+
+            using var idatStream = new MemoryStream();
+            idatStream.WriteByte(0x78);
+            idatStream.WriteByte(0x9C);
+            using (var deflate = new DeflateStream(idatStream, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                deflate.Write(scanlines, 0, scanlines.Length);
+            }
+
+            uint adler = CalculateAdler32(scanlines);
+            idatStream.WriteByte((byte)((adler >> 24) & 0xFF));
+            idatStream.WriteByte((byte)((adler >> 16) & 0xFF));
+            idatStream.WriteByte((byte)((adler >> 8) & 0xFF));
+            idatStream.WriteByte((byte)(adler & 0xFF));
+            WriteChunk(output, "IDAT", idatStream.ToArray());
+
+            WriteChunk(output, "IEND", Array.Empty<byte>());
+            return output.ToArray();
+        }
+
+        private static void WriteUInt32BigEndian(byte[] buffer, int offset, uint value)
+        {
+            buffer[offset] = (byte)((value >> 24) & 0xFF);
+            buffer[offset + 1] = (byte)((value >> 16) & 0xFF);
+            buffer[offset + 2] = (byte)((value >> 8) & 0xFF);
+            buffer[offset + 3] = (byte)(value & 0xFF);
+        }
+
+        private static void WriteChunk(Stream stream, string type, byte[] data)
+        {
+            byte[] typeBytes = System.Text.Encoding.ASCII.GetBytes(type);
+            uint length = (uint)data.Length;
+            stream.WriteByte((byte)((length >> 24) & 0xFF));
+            stream.WriteByte((byte)((length >> 16) & 0xFF));
+            stream.WriteByte((byte)((length >> 8) & 0xFF));
+            stream.WriteByte((byte)(length & 0xFF));
+            stream.Write(typeBytes, 0, 4);
+            if (data.Length > 0)
+            {
+                stream.Write(data, 0, data.Length);
+            }
+
+            uint crc = 0xFFFFFFFFu;
+            for (int i = 0; i < 4; i++)
+            {
+                crc = CrcTable[(crc ^ typeBytes[i]) & 0xFF] ^ (crc >> 8);
+            }
+            for (int i = 0; i < data.Length; i++)
+            {
+                crc = CrcTable[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+            }
+            crc ^= 0xFFFFFFFFu;
+
+            stream.WriteByte((byte)((crc >> 24) & 0xFF));
+            stream.WriteByte((byte)((crc >> 16) & 0xFF));
+            stream.WriteByte((byte)((crc >> 8) & 0xFF));
+            stream.WriteByte((byte)(crc & 0xFF));
+        }
+
+        private static uint[] BuildCrcTable()
+        {
+            var table = new uint[256];
+            for (uint i = 0; i < 256; i++)
+            {
+                uint c = i;
+                for (int k = 0; k < 8; k++)
+                {
+                    c = (c & 1) != 0 ? 0xedb88320u ^ (c >> 1) : c >> 1;
+                }
+                table[i] = c;
+            }
+            return table;
+        }
+
+        private static uint CalculateAdler32(byte[] data)
+        {
+            uint s1 = 1;
+            uint s2 = 0;
+            for (int i = 0; i < data.Length; i++)
+            {
+                s1 = (s1 + data[i]) % 65521;
+                s2 = (s2 + s1) % 65521;
+            }
+            return (s2 << 16) | s1;
+        }
+    }
+}

--- a/src/ProGPU.Wpf/WpfPortablePresentationSourceBridge.cs
+++ b/src/ProGPU.Wpf/WpfPortablePresentationSourceBridge.cs
@@ -42,6 +42,51 @@ public sealed class WpfPortablePresentationSourceBridge : IDisposable
 
     public IntPtr Handle => _source.Handle;
 
+    /// <summary>
+    /// Resolves the native OS window handle backing this host's window on this ProGPU/Silk.NET-
+    /// hosted platform - an NSWindow* on macOS, an HWND on Windows, or an X11 Window id on Linux
+    /// (via <see cref="Silk.NET.Core.Contexts.INativeWindow"/>). Unlike <see cref="Handle"/> -
+    /// which is a synthetic identifier WPF's portable <c>HwndSource</c> compat shim allocates for
+    /// itself and never a real OS handle - this is the genuine platform handle. Intended for
+    /// consumers that need it for OS-level integration (e.g. IME/NSTextInputClient) that WPF's
+    /// own <c>PresentationSource</c>/<c>HwndSource</c> doesn't provide on this host.
+    /// </summary>
+    public bool TryGetNativeHandle(out IntPtr handle)
+    {
+        handle = IntPtr.Zero;
+        if (_host.SilkWindow is not { } silkWindow)
+        {
+            return false;
+        }
+
+        var native = silkWindow.Native;
+        if (native is null)
+        {
+            return false;
+        }
+
+        if (native.Cocoa is { } cocoa && cocoa != IntPtr.Zero)
+        {
+            handle = cocoa;
+            return true;
+        }
+
+        // Win32 = (HWnd, HDC, HInstance); X11 = (Display, Window).
+        if (native.Win32 is { Item1: var hwnd } && hwnd != IntPtr.Zero)
+        {
+            handle = hwnd;
+            return true;
+        }
+
+        if (native.X11 is { Item2: var x11Window } && x11Window != UIntPtr.Zero)
+        {
+            handle = (IntPtr)x11Window;
+            return true;
+        }
+
+        return false;
+    }
+
     public object? RootVisual
     {
         get => _source.RootVisual;

--- a/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
+++ b/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
@@ -200,6 +200,25 @@ public sealed class WpfPortableWindowActivation : IDisposable
         return false;
     }
 
+    /// <summary>
+    /// Resolves the native OS window handle backing a WPF <see cref="Window"/> on this ProGPU/
+    /// Silk.NET-hosted platform. Thin wrapper over the resolution that already lives on the
+    /// window's <see cref="WpfPortablePresentationSourceBridge.TryGetNativeHandle"/> - see that
+    /// member for what the handle actually is and why it exists alongside the portable
+    /// <c>Handle</c> WPF's <c>HwndSource</c> compat shim already exposes.
+    /// </summary>
+    public static bool TryGetNativeWindowHandle(object? window, out IntPtr handle)
+    {
+        handle = IntPtr.Zero;
+        if (!TryGetActiveHost(window, out var host) ||
+            host?.PortablePresentationSourceBridge is not { } bridge)
+        {
+            return false;
+        }
+
+        return bridge.TryGetNativeHandle(out handle);
+    }
+
     public static bool TryRegisterPresentationFrameworkLauncherService()
     {
         if (PortableWpfServiceRegistry.TryGetLauncherService(

--- a/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
+++ b/src/ProGPU.Wpf/WpfPortableWindowActivation.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 using System.Runtime.CompilerServices;
 using ProGPU.Wpf.Interop;
 using System.Windows.Media.ProGPU.Platform;
@@ -1305,6 +1306,13 @@ public sealed class WpfPortableWindowActivation : IDisposable
 
             ProcessHostInputAndRequestRender(e);
         }
+        catch (Exception exception)
+        {
+            if (!TryReportInputExceptionToWindowDispatcher(exception))
+            {
+                throw;
+            }
+        }
         finally
         {
             if (releaseButtonAfterDispatch)
@@ -1312,6 +1320,18 @@ public sealed class WpfPortableWindowActivation : IDisposable
                 _pressedMouseButtons.Remove(e.Button);
             }
         }
+    }
+
+    private bool TryReportInputExceptionToWindowDispatcher(Exception exception)
+    {
+        if (!TryGetWindowActivationService(out var activationService))
+        {
+            return false;
+        }
+
+        return activationService.TryBeginInvokeInput(
+            Window,
+            () => ExceptionDispatchInfo.Capture(exception).Throw());
     }
 
     private void ProcessHostInputAndRequestRender(WpfInputEventArgs e)


### PR DESCRIPTION
## Summary

A set of independent small fixes accumulated while running real WPF workloads (SharpDevelop-derived designer, AvalonDock) on the portable stack:

- **Mouse up routing** (`SilkNetWpfInputService`): released-button events were dropped in a specific ordering window.
- **Designer unhandled exception handler** (`WpfPortableWindowActivation`): input callbacks that throw now marshal to the window dispatcher instead of tearing down the native loop — mirrors what the Framework designer surface did.
- **Handle exposure** (`WpfPortablePresentationSourceBridge` + activation): expose the portable native handle for interop scenarios that need it (accessibility bridges, external automation).
- **Custom chrome sync** (`Window`): `SetPortableCustomChrome` via Style Setter can race ahead of `Show()`'s activate; re-sync border state after activation exists or the native title bar stays visible (AvalonDock floating windows).
- **Image rendering** (`ProGpuCompositionCommandSink`): fix for images not repainting in one composition path. Note this touches the same method as #101's GeometryGroup ABI fix — rebased and verified against it.
- **Screenshot** (new `ProGpuWpfScreenshot`): cross-platform `CopyScreen` equivalent reading the compositor backbuffer, since `Graphics.CopyFromScreen` has no portable implementation.

Each commit is self-contained; happy to split into individual PRs if preferred.

## Tests

- Full managed transport builds clean on macOS arm64; all changes exercised by our downstream integration lane (MvpApp/Toolkit live validation).