### PR TITLE
[WIP] Give ComboBox/menu/tooltip popups square corners on macOS

### DIFF
--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19280,6 +19280,67 @@ public sealed class WpfManagedProjectGraphTests
             item => string.Equals(item.Attribute("Include")?.Value, include, StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void PopupSurfacesRenderWithoutMacOsRoundedCorners()
+    {
+        var nativeWindowTypes = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Backend",
+            "NativeWindowTypes.cs"));
+
+        Assert.Contains("bool IsPopup = false)", nativeWindowTypes, StringComparison.Ordinal);
+        Assert.Contains("IsPopup: false);", nativeWindowTypes, StringComparison.Ordinal);
+
+        var windowController = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Backend",
+            "SilkWindowController.cs"));
+
+        Assert.Contains("public bool SetIsPopup(bool value)", windowController, StringComparison.Ordinal);
+        Assert.Contains("_state = _state with { IsPopup = value };", windowController, StringComparison.Ordinal);
+
+        var macPlatform = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Backend",
+            "MacOsNativeWindowPlatform.cs"));
+
+        // NSWindowStyleMaskTitled forces OS-drawn rounded window corners even with the title bar
+        // hidden/transparent - only a truly borderless (styleMask 0) window renders square on
+        // macOS. Popup surfaces (ComboBox/ContextMenu/ToolTip drop-downs) reused the same
+        // "no decorations" chrome path as chromeless top-level windows, which intentionally keep
+        // StyleTitled for their own OS-drawn shadow/rounding, so every popup came out rounded -
+        // something real WPF popups never are.
+        Assert.Contains("if (state.IsPopup)", macPlatform, StringComparison.Ordinal);
+        AssertGuardBefore(macPlatform, "if (state.IsPopup)", "style |= StyleTitled | StyleFullSizeContentView;");
+
+        var windowOptions = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "ProGpuWpfWindowOptions.cs"));
+
+        Assert.Contains("internal bool IsPopupSurface { get; set; }", windowOptions, StringComparison.Ordinal);
+
+        var windowHost = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "ProGpuWpfWindowHost.cs"));
+
+        Assert.Contains("_windowController.SetIsPopup(_options.IsPopupSurface);", windowHost, StringComparison.Ordinal);
+
+        var popupHost = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "WpfPortableNativePopupHost.cs"));
+
+        Assert.Contains("IsPopupSurface = true,", popupHost, StringComparison.Ordinal);
+    }
+
     private static void AssertGuardBefore(string source, string guard, string guardedCall)
     {
         var guardIndex = source.IndexOf(guard, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -1398,6 +1398,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         _window = Window.Create(windowOptions);
         _dpiWindowHintsConfigured = SilkNetGlfwDpiService.TryConfigureDpiWindowHints();
         _windowController = new SilkWindowController(_window);
+        _windowController.SetIsPopup(_options.IsPopupSurface);
         ApplyWindowBorderToController();
         _hasNativeWindowCloseStarted = false;
         _window.Load += OnLoad;

--- a/src/ProGPU.Wpf/ProGpuWpfWindowOptions.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowOptions.cs
@@ -37,6 +37,8 @@ public sealed class ProGpuWpfWindowOptions
 
     internal bool NativePointerCoordinatesAreOwnerRelative { get; set; }
 
+    internal bool IsPopupSurface { get; set; }
+
     public ProGpuWpfWindowBorder WindowBorder { get; set; } = ProGpuWpfWindowBorder.Resizable;
 
     public ProGpuWpfWindowState WindowState { get; set; } = ProGpuWpfWindowState.Normal;

--- a/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
+++ b/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
@@ -117,6 +117,7 @@ internal sealed class WpfPortableNativePopupHost : IWpfPortableNativePopupHost
             ShowActivated = false,
             TransparentFramebuffer = request.IsTransparent,
             WindowBorder = ProGpuWpfWindowBorder.Hidden,
+            IsPopupSurface = true,
             EnablePortablePopupService = false,
             IncludePortablePopupRootsInWpfReplay = true,
             NativePointerCoordinatesAreOwnerRelative = OperatingSystem.IsMacOS(),


### PR DESCRIPTION
## Summary
- `WpfPortableNativePopupHost` creates every popup surface (`ComboBox`, `ContextMenu`, `ToolTip` drop-downs) through the same "no decorations" native chrome path as chromeless top-level windows. On macOS that path keeps `NSWindowStyleMaskTitled` and only hides the title bar via transparency, so the OS still draws rounded corners on the popup - real WPF popups are always square.
- Adds `internal bool IsPopupSurface` to `ProGpuWpfWindowOptions`, set by `WpfPortableNativePopupHost`, threaded through `ProGpuWpfWindowHost` to `SilkWindowController.SetIsPopup(bool)`.
- Depends on the companion ProGPU submodule fix (wieslawsoltes/ProGPU#145), which makes `MacOsNativeWindowPlatform.ApplyChrome` render `IsPopup` surfaces as truly borderless (`NSWindowStyleMaskBorderless`) instead of titled-but-transparent.
- Added a graph test (`PopupSurfacesRenderWithoutMacOsRoundedCorners`) asserting the `IsPopupSurface`/`IsPopup` wiring end-to-end, following this repo's existing structural-test convention for platform chrome that can't be exercised without a real display.

## Investigation
While researching this, I also verified with a minimal standalone repro app (`ComboBox` with short/long/many-item lists) driven via DevFlow that the *managed* popup sizing/clamping was already correct and matched real WPF before touching any code:
- Popup width defaults to the `ComboBox`'s own width (`MinWidth={TemplateBinding ActualWidth}` in both the Classic and Fluent themes) and only grows when content needs more space.
- Popup height is already clamped against `MaxDropDownHeight` with a `ScrollViewer` appearing for overflow.

So only the native macOS window chrome needed a fix - the WPF-side templates and `Popup`/`PopupRoot` sizing logic were untouched.

## Test plan
- [x] `dotnet build src/ProGPU.Wpf.Tests/ProGPU.Wpf.Tests.csproj -c Debug` succeeds.
- [x] Full `WpfManagedProjectGraphTests` suite: 76 passed, 2 pre-existing failures unrelated to this change (`MediaContextHasPortableRenderWakeupBoundary`, `RealPresentationFrameworkSmokeGuardsNativePlatformEntrypoints`), 0 regressions, new `PopupSurfacesRenderWithoutMacOsRoundedCorners` test passes.
- [x] End-to-end verification against a locally rebuilt `LibreWPF.ProGPU` package in a minimal standalone WPF app via DevFlow, before/after the fix.

Marked WIP/draft pending the companion ProGPU PR (wieslawsoltes/ProGPU#145) merging first, matching this repo's existing convention for submodule-dependent changes.