### PR TITLE
Stabilize hosted live input validation

### DIFF
--- a/eng/run-progpu-wpf-mvp.sh
+++ b/eng/run-progpu-wpf-mvp.sh
@@ -56,7 +56,7 @@ if [[ "${PROGPU_WPF_MVP_LIVE_VALIDATE:-0}" == "1" ]]; then
   live_log="$(mktemp "${TMPDIR:-/tmp}/progpu-wpf-mvp-live.XXXXXX")"
   live_status="$(mktemp "${TMPDIR:-/tmp}/progpu-wpf-mvp-live-status.XXXXXX")"
   apphost_pid=""
-  live_validation_timeout_seconds="${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-60}"
+  live_validation_timeout_seconds="${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-180}"
   if [[ ! "${live_validation_timeout_seconds}" =~ ^[1-9][0-9]*$ ]]; then
     echo "Invalid PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS value '${live_validation_timeout_seconds}'." >&2
     exit 1

--- a/samples/ProGPU.Wpf.MvpApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.MvpApp/MainWindow.xaml.cs
@@ -2513,6 +2513,12 @@ public partial class MainWindow : Window
         double verticalDelta,
         out string targetState)
     {
+        Point initialCenter = target.TranslatePoint(
+            new Point(Math.Max(1.0, target.ActualWidth) / 2.0, Math.Max(1.0, target.ActualHeight) / 2.0),
+            this);
+        target.BringIntoView();
+        target.UpdateLayout();
+
         targetState =
             $"{description}.IsVisible={target.IsVisible}, " +
             $"{description}.ActualSize={target.ActualWidth:0.###}x{target.ActualHeight:0.###}, " +
@@ -2530,10 +2536,18 @@ public partial class MainWindow : Window
         Point center = target.TranslatePoint(
             new Point(Math.Max(1.0, target.ActualWidth) / 2.0, Math.Max(1.0, target.ActualHeight) / 2.0),
             this);
+        double layoutDeltaX = center.X - initialCenter.X;
+        double layoutDeltaY = center.Y - initialCenter.Y;
+        if (Math.Abs(layoutDeltaX) > 0.5 || Math.Abs(layoutDeltaY) > 0.5)
+        {
+            targetState += $", BringIntoViewDelta=({layoutDeltaX:0.###}, {layoutDeltaY:0.###})";
+            return false;
+        }
+
         Point moved = new(center.X + horizontalDelta, center.Y + verticalDelta);
         object? hit = InputHitTest(center);
         targetState += $", Input=({center.X:0.###}, {center.Y:0.###}), InputHitTest={DescribeInputElement(hit)}";
-        if (hit == null)
+        if (hit == null || !IsInputElementWithinTarget(hit, target))
         {
             return false;
         }
@@ -2841,6 +2855,7 @@ public partial class MainWindow : Window
                 break;
             }
 
+            WakeLiveRenderHost(liveHost);
             await Task.Delay(LiveValidationRetryDelay);
         }
 
@@ -3240,6 +3255,37 @@ public partial class MainWindow : Window
         return element is IInputElement
             ? "InputElement"
             : "Element";
+    }
+
+    private static bool IsInputElementWithinTarget(object hit, FrameworkElement target)
+    {
+        if (ReferenceEquals(hit, target))
+        {
+            return true;
+        }
+
+        var current = hit as DependencyObject;
+        while (current != null)
+        {
+            if (ReferenceEquals(current, target))
+            {
+                return true;
+            }
+
+            DependencyObject? parent = null;
+            try
+            {
+                parent = VisualTreeHelper.GetParent(current);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            parent ??= LogicalTreeHelper.GetParent(current);
+            current = parent;
+        }
+
+        return false;
     }
 
     private LiveLayoutSize CaptureLiveLayoutSize(ProGpuWpfWindowHost liveHost)

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -3782,6 +3782,34 @@ public partial class MainWindow : Window
 
     private async Task<string> ValidateLiveInputAsync(ProGpuWpfWindowHost liveHost)
     {
+        Console.WriteLine("ProGPU WPF Toolkit live input validation step: transient surface quiescence.");
+        await InvokeWithLiveHostWakeAsync(
+            liveHost,
+            () =>
+            {
+                ActionDropDownButton.IsOpen = false;
+                SplitActionButton.IsOpen = false;
+                DockDocumentContextMenu.IsOpen = false;
+                DockAnchorableContextMenu.IsOpen = false;
+                Point safePointerPoint = ActivateEditorButton.TranslatePoint(
+                    new Point(
+                        Math.Max(1.0, ActivateEditorButton.ActualWidth) / 2.0,
+                        Math.Max(1.0, ActivateEditorButton.ActualHeight) / 2.0),
+                    this);
+                RaiseHostInput(
+                    liveHost,
+                    WpfInputEventKind.MouseMove,
+                    x: safePointerPoint.X,
+                    y: safePointerPoint.Y);
+                ActivateEditorButton.Focus();
+                Keyboard.Focus(ActivateEditorButton);
+            },
+            DispatcherPriority.Send);
+        await WaitForLiveConditionAsync(
+            liveHost,
+            () => GetAvalonDockAutoHideWindowModel() == null,
+            "Toolkit live transient AvalonDock auto-hide overlay close");
+
         Console.WriteLine("ProGPU WPF Toolkit live input validation step: filter focus.");
         string lastTargetState = "not checked";
         bool focusedFilter = false;

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -4920,6 +4920,11 @@ public partial class MainWindow : Window
 
         object? hit = InputHitTest(center);
         targetState += $", Input=({center.X:0.###}, {center.Y:0.###}), InputHitTest={DescribeInputElement(hit)}";
+        if (hit == null || !IsInputElementWithinTarget(hit, target))
+        {
+            return false;
+        }
+
         if (!TryLiveHostGpuHitWithinTarget(liveHost, center.X, center.Y, target, out string gpuHitState))
         {
             targetState += $", {gpuHitState}";

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -3791,6 +3791,11 @@ public partial class MainWindow : Window
                 SplitActionButton.IsOpen = false;
                 DockDocumentContextMenu.IsOpen = false;
                 DockAnchorableContextMenu.IsOpen = false;
+                if (DockManager.AutoHideWindow is { } transientAutoHideWindow)
+                {
+                    transientAutoHideWindow.IsHitTestVisible = false;
+                }
+
                 Point safePointerPoint = ActivateEditorButton.TranslatePoint(
                     new Point(
                         Math.Max(1.0, ActivateEditorButton.ActualWidth) / 2.0,
@@ -4334,6 +4339,11 @@ public partial class MainWindow : Window
             liveHost,
             () =>
             {
+                if (DockManager.AutoHideWindow is { } autoHideWindow)
+                {
+                    autoHideWindow.IsHitTestVisible = true;
+                }
+
                 EnsureAutoHideOverlayAnchorables();
                 _avalonDockAutoHideOverlayIndex = -1;
                 ViewModel.LastAvalonDockAutoHideOverlayTarget = string.Empty;

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -2966,6 +2966,12 @@ public partial class MainWindow : Window
         return autoHideWindow?.Model;
     }
 
+    private FrameworkElement? GetAvalonDockAutoHideArea()
+    {
+        DockManager.ApplyTemplate();
+        return DockManager.Template?.FindName("PART_AutoHideArea", DockManager) as FrameworkElement;
+    }
+
     private static bool AutoHideOverlayModelContains(object? overlayModel, LayoutAnchorable expectedContent)
     {
         if (ReferenceEquals(overlayModel, expectedContent))
@@ -3796,6 +3802,11 @@ public partial class MainWindow : Window
                     transientAutoHideWindow.IsHitTestVisible = false;
                 }
 
+                if (GetAvalonDockAutoHideArea() is { } transientAutoHideArea)
+                {
+                    transientAutoHideArea.IsHitTestVisible = false;
+                }
+
                 Point safePointerPoint = ActivateEditorButton.TranslatePoint(
                     new Point(
                         Math.Max(1.0, ActivateEditorButton.ActualWidth) / 2.0,
@@ -4339,6 +4350,11 @@ public partial class MainWindow : Window
             liveHost,
             () =>
             {
+                if (GetAvalonDockAutoHideArea() is { } autoHideArea)
+                {
+                    autoHideArea.IsHitTestVisible = true;
+                }
+
                 if (DockManager.AutoHideWindow is { } autoHideWindow)
                 {
                     autoHideWindow.IsHitTestVisible = true;

--- a/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
+++ b/samples/ProGPU.Wpf.ToolkitApp/MainWindow.xaml.cs
@@ -4528,9 +4528,20 @@ public partial class MainWindow : Window
             },
             DispatcherPriority.Send);
 
+        Button splitActionButtonPart = await InvokeWithLiveHostWakeAsync(
+            liveHost,
+            () =>
+            {
+                SplitActionButton.ApplyTemplate();
+                SplitActionButton.UpdateLayout();
+                return SplitActionButton.Template?.FindName("PART_ActionButton", SplitActionButton) as Button
+                    ?? throw new InvalidOperationException("Expected Toolkit SplitButton template action button.");
+            },
+            DispatcherPriority.Send);
+
         for (int attempt = 0; attempt < LiveValidationMaxAttempts; attempt++)
         {
-            await ClickLiveControlAsync(liveHost, SplitActionButton, "SplitActionButton");
+            await ClickLiveControlAsync(liveHost, splitActionButtonPart, "SplitActionButton.PART_ActionButton");
             if (await InvokeWithLiveHostWakeAsync(
                     liveHost,
                     () => string.Equals(ViewModel.Status, "Applied owner ProGPU", StringComparison.Ordinal),

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -14035,7 +14035,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("PROGPU_WPF_MVP_LIVE_VALIDATE", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("PROGPU_WPF_MVP_LIVE_VALIDATE_STATUS_PATH", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS", mvpRunScript, StringComparison.Ordinal);
-        Assert.Contains("live_validation_timeout_seconds=\"${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-60}\"", mvpRunScript, StringComparison.Ordinal);
+        Assert.Contains("live_validation_timeout_seconds=\"${PROGPU_WPF_MVP_LIVE_VALIDATE_TIMEOUT_SECONDS:-180}\"", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("live_validation_deadline=$((SECONDS + live_validation_timeout_seconds))", mvpRunScript, StringComparison.Ordinal);
         Assert.Contains("while (( SECONDS < live_validation_deadline )); do", mvpRunScript, StringComparison.Ordinal);
         Assert.DoesNotContain("for _ in {1..600}; do", mvpRunScript, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -10741,6 +10741,9 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("WriteLiveValidationStatus", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("Toolkit live transient AvalonDock auto-hide overlay close", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("transientAutoHideWindow.IsHitTestVisible = false;", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("transientAutoHideArea.IsHitTestVisible = false;", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("DockManager.Template?.FindName(\"PART_AutoHideArea\", DockManager)", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("autoHideArea.IsHitTestVisible = true;", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("autoHideWindow.IsHitTestVisible = true;", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("ProGPU WPF Toolkit live input validation details:", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("ProGPU WPF Toolkit live input validation succeeded:", mainWindowCodeBehind, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -10704,6 +10704,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("DescribeInputElements(owners)", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("double layoutDeltaX = center.X - initialCenter.X;", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("BringIntoViewDelta=({layoutDeltaX:0.###}, {layoutDeltaY:0.###})", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("hit == null || !IsInputElementWithinTarget(hit, target)", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("WakeLiveRenderHost(liveHost);\n            await Task.Delay(LiveValidationRetryDelay);", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.DoesNotContain("TryHitTestOwners(liveHost, x, y, out object?[] owners)", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.DoesNotContain("owners.Select(DescribeInputElement)", mainWindowCodeBehind, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -10705,6 +10705,8 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("double layoutDeltaX = center.X - initialCenter.X;", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("BringIntoViewDelta=({layoutDeltaX:0.###}, {layoutDeltaY:0.###})", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("hit == null || !IsInputElementWithinTarget(hit, target)", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("SplitActionButton.Template?.FindName(\"PART_ActionButton\", SplitActionButton)", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("ClickLiveControlAsync(liveHost, splitActionButtonPart, \"SplitActionButton.PART_ActionButton\")", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("WakeLiveRenderHost(liveHost);\n            await Task.Delay(LiveValidationRetryDelay);", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.DoesNotContain("TryHitTestOwners(liveHost, x, y, out object?[] owners)", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.DoesNotContain("owners.Select(DescribeInputElement)", mainWindowCodeBehind, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -10740,6 +10740,8 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("LiveValidationStartupMaxAttempts = 1200", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("WriteLiveValidationStatus", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("Toolkit live transient AvalonDock auto-hide overlay close", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("transientAutoHideWindow.IsHitTestVisible = false;", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("autoHideWindow.IsHitTestVisible = true;", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("ProGPU WPF Toolkit live input validation details:", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("ProGPU WPF Toolkit live input validation succeeded:", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.DoesNotContain("TryGetPortableActivationHost", mainWindowCodeBehind, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -10739,6 +10739,7 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("PROGPU_WPF_TOOLKIT_LIVE_VALIDATE_STATUS_PATH", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("LiveValidationStartupMaxAttempts = 1200", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("WriteLiveValidationStatus", mainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("Toolkit live transient AvalonDock auto-hide overlay close", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("ProGPU WPF Toolkit live input validation details:", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("ProGPU WPF Toolkit live input validation succeeded:", mainWindowCodeBehind, StringComparison.Ordinal);
         Assert.DoesNotContain("TryGetPortableActivationHost", mainWindowCodeBehind, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -14457,6 +14457,9 @@ public sealed class WpfManagedProjectGraphTests
         Assert.Contains("MVP live ScrollViewer MouseWheel delta", mvpMainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("TryRaiseLiveThumbDrag(", mvpMainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("input Thumb tab activation", mvpMainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("target.BringIntoView();", mvpMainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("hit == null || !IsInputElementWithinTarget(hit, target)", mvpMainWindowCodeBehind, StringComparison.Ordinal);
+        Assert.Contains("BringIntoViewDelta=({layoutDeltaX:0.###}, {layoutDeltaY:0.###})", mvpMainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("IsMouseOver={target.IsMouseOver}", mvpMainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("!ReferenceEquals(Mouse.Captured, target)", mvpMainWindowCodeBehind, StringComparison.Ordinal);
         Assert.Contains("InputThumbDragStartedCount <= startedBefore", mvpMainWindowCodeBehind, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- align the MVP wrapper deadline with its bounded live-validation retry budget
- require WPF input-tree and retained GPU-owner agreement before Toolkit click injection
- close popup/context/auto-hide surfaces and wait for quiescence before Toolkit input
- bring the MVP drag Thumb into view, publish layout/render changes, and require target ancestry before drag injection
- preserve every existing geometry, input, rendering, capture, and performance assertion
- lock the harness contracts in project-graph regression tests

## Hosted evidence

- Post-merge run 34520535573: package gates passed; MVP wrapper killed the live sequence at 60 seconds.
- PR run 34525168013: MVP passed with the corrected budget; Toolkit exposed disagreement between WPF and retained GPU hit maps at SplitButton.
- PR run 34527903219: MVP passed; Toolkit startup exposed a lingering AvalonDock auto-hide overlay covering FilterTextBox.
- PR run 34531110755: package gates passed; MVP reached the Thumb test but its logically visible Thumb remained outside the active viewport.

Each failure now has a narrow deterministic correction based on its exact logged state. No validation is disabled or relaxed.

## Local validation

- bash syntax check: passed
- git diff check: passed
- ProGpuWpfSdkProvidesSwitchOnlyPackagingSurface (Release): passed
- ProGpuWpfToolkitSampleExercisesXceedToolkitAndAvalonDock (Release): passed

The live Cocoa sample execution requires the hosted macOS package graph and is validated by exact-head CI.