### PR TITLE
Integrate square-corner portable popup surfaces

### DIFF
--- a/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
+++ b/src/ProGPU.Wpf.Tests/Composition/WpfManagedProjectGraphTests.cs
@@ -19280,6 +19280,67 @@ public sealed class WpfManagedProjectGraphTests
             item => string.Equals(item.Attribute("Include")?.Value, include, StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void PopupSurfacesRenderWithoutMacOsRoundedCorners()
+    {
+        var nativeWindowTypes = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Backend",
+            "NativeWindowTypes.cs"));
+
+        Assert.Contains("bool IsPopup = false)", nativeWindowTypes, StringComparison.Ordinal);
+        Assert.Contains("IsPopup: false);", nativeWindowTypes, StringComparison.Ordinal);
+
+        var windowController = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Backend",
+            "SilkWindowController.cs"));
+
+        Assert.Contains("public bool SetIsPopup(bool value)", windowController, StringComparison.Ordinal);
+        Assert.Contains("_state = _state with { IsPopup = value };", windowController, StringComparison.Ordinal);
+
+        var macPlatform = File.ReadAllText(FindRepoPath(
+            "external",
+            "ProGPU",
+            "src",
+            "ProGPU.Backend",
+            "MacOsNativeWindowPlatform.cs"));
+
+        // NSWindowStyleMaskTitled forces OS-drawn rounded window corners even with the title bar
+        // hidden/transparent - only a truly borderless (styleMask 0) window renders square on
+        // macOS. Popup surfaces (ComboBox/ContextMenu/ToolTip drop-downs) reused the same
+        // "no decorations" chrome path as chromeless top-level windows, which intentionally keep
+        // StyleTitled for their own OS-drawn shadow/rounding, so every popup came out rounded -
+        // something real WPF popups never are.
+        Assert.Contains("if (state.IsPopup)", macPlatform, StringComparison.Ordinal);
+        AssertGuardBefore(macPlatform, "if (state.IsPopup)", "style |= StyleTitled | StyleFullSizeContentView;");
+
+        var windowOptions = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "ProGpuWpfWindowOptions.cs"));
+
+        Assert.Contains("internal bool IsPopupSurface { get; set; }", windowOptions, StringComparison.Ordinal);
+
+        var windowHost = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "ProGpuWpfWindowHost.cs"));
+
+        Assert.Contains("_windowController.SetIsPopup(_options.IsPopupSurface);", windowHost, StringComparison.Ordinal);
+
+        var popupHost = File.ReadAllText(FindRepoPath(
+            "src",
+            "ProGPU.Wpf",
+            "WpfPortableNativePopupHost.cs"));
+
+        Assert.Contains("IsPopupSurface = true,", popupHost, StringComparison.Ordinal);
+    }
+
     private static void AssertGuardBefore(string source, string guard, string guardedCall)
     {
         var guardIndex = source.IndexOf(guard, StringComparison.Ordinal);

--- a/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowHost.cs
@@ -1398,6 +1398,7 @@ public unsafe sealed class ProGpuWpfWindowHost : IDisposable
         _window = Window.Create(windowOptions);
         _dpiWindowHintsConfigured = SilkNetGlfwDpiService.TryConfigureDpiWindowHints();
         _windowController = new SilkWindowController(_window);
+        _windowController.SetIsPopup(_options.IsPopupSurface);
         ApplyWindowBorderToController();
         _hasNativeWindowCloseStarted = false;
         _window.Load += OnLoad;

--- a/src/ProGPU.Wpf/ProGpuWpfWindowOptions.cs
+++ b/src/ProGPU.Wpf/ProGpuWpfWindowOptions.cs
@@ -37,6 +37,8 @@ public sealed class ProGpuWpfWindowOptions
 
     internal bool NativePointerCoordinatesAreOwnerRelative { get; set; }
 
+    internal bool IsPopupSurface { get; set; }
+
     public ProGpuWpfWindowBorder WindowBorder { get; set; } = ProGpuWpfWindowBorder.Resizable;
 
     public ProGpuWpfWindowState WindowState { get; set; } = ProGpuWpfWindowState.Normal;

--- a/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
+++ b/src/ProGPU.Wpf/WpfPortableNativePopupHost.cs
@@ -117,6 +117,7 @@ internal sealed class WpfPortableNativePopupHost : IWpfPortableNativePopupHost
             ShowActivated = false,
             TransparentFramebuffer = request.IsTransparent,
             WindowBorder = ProGpuWpfWindowBorder.Hidden,
+            IsPopupSurface = true,
             EnablePortablePopupService = false,
             IncludePortablePopupRootsInWpfReplay = true,
             NativePointerCoordinatesAreOwnerRelative = OperatingSystem.IsMacOS(),


### PR DESCRIPTION
Reconciles LibreWPF #118 with the current rendering-port branch while preserving the contributor commit in the merge ancestry. The companion ProGPU #145 is already merged and the current ProGPU submodule pin contains SilkWindowController.SetIsPopup. The resulting diff is the popup flag wiring and its graph test; no unrelated submodule change is retained. This integration PR exists because GitHub could not update the contributor organization-fork branch across the gitlink conflict.